### PR TITLE
Fix in README: Usage of venvs via pdm run in READMEs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -17,6 +17,6 @@ pdm install
 ```sh
 
 # Start the development server
-python3 api/api.py
+pdm run python3 api/api.py
 
 ```

--- a/db/README.md
+++ b/db/README.md
@@ -21,6 +21,6 @@ To generate the default empty **db/basil.db** database:
 cd db && cd models
 
 # Initialize the sqlite database, you will find it in db/basil.db
-python3 init_db.py
+pdm run python3 init_db.py
 
 ```


### PR DESCRIPTION
Since pdm is creating a virtual environment with pdm install, we need to run the api backend and db creation with pdm run.