### PR TITLE
Docker app port

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -7,7 +7,9 @@ COPY . /BASIL-APP
 WORKDIR /BASIL-APP/app
 # Set the public ip
 ARG API_ENDPOINT=localhost:5000
+ARG APP_PORT=9000
 RUN sed -i "s#http://localhost:5000#${API_ENDPOINT}#g" src/app/Constants/constants.tsx && \
+    sed -i "s#--port 9000#--port ${APP_PORT}#g" app/package.json && \
     npm install -d --verbose
 RUN npm run build
 

--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -9,7 +9,7 @@ WORKDIR /BASIL-APP/app
 ARG API_ENDPOINT=localhost:5000
 ARG APP_PORT=9000
 RUN sed -i "s#http://localhost:5000#${API_ENDPOINT}#g" src/app/Constants/constants.tsx && \
-    sed -i "s#--port 9000#--port ${APP_PORT}#g" app/package.json && \
+    sed -i "s#--port 9000#--port ${APP_PORT}#g" package.json && \
     npm install -d --verbose
 RUN npm run build
 

--- a/docs/source/how_to_run_it.rst
+++ b/docs/source/how_to_run_it.rst
@@ -56,12 +56,14 @@ At the same way you can build the APP project using Dockerfile-app
 
 To be able to reach the API project you need to specify the following build argument:
 
- + API_ENDPOINT (e.g. http://api-server-it:yourport or http://api-server-it/reverse-proxy-route)
+ + API_ENDPOINT (e.g. http://api-server-it:yourport)
+ + APP_PORT
 
 .. code-block:: bash
 
    docker build \
       --build-arg API_ENDPOINT=http://api-server-url:yourport \
+      --build-arg APP_PORT=yourport \
       -f Dockerfile-app \
       -t basil-app-image .
 


### PR DESCRIPTION
Add a build argument in the Dockerfile-app to be able to specify the deployment application port building the app docker container.