### PR TITLE
Rever changes to Test Case gap implemented in v1.4

### DIFF
--- a/app/src/app/Mapping/MappingListingTable.tsx
+++ b/app/src/app/Mapping/MappingListingTable.tsx
@@ -318,15 +318,6 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
                     {coverageFormat(test_case['coverage'])}% Coverage
                   </Label>
                 </FlexItem>
-                {indirect == false && test_case['coverage'] < 100 ? (
-                  <FlexItem>
-                    <Label color='red' name='label-test-case-coverage' variant='outline' isCompact>
-                      {coverageFormat(100 - test_case['coverage'])}% Gap
-                    </Label>
-                  </FlexItem>
-                ) : (
-                  ''
-                )}
                 <FlexItem align={{ default: 'alignRight' }}>
                   {indirect == false && auth.isLogged() ? (
                     <React.Fragment>
@@ -422,7 +413,7 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
                 {test_spec['gap'] != 0 ? (
                   <React.Fragment>
                     <FlexItem>
-                      <Label color='red' name='label-sw-requirement-coverage' variant='outline' isCompact>
+                      <Label color='red' name='label-test-specification-coverage' variant='outline' isCompact>
                         {coverageFormat(test_spec['gap'])}% Gap
                       </Label>
                     </FlexItem>

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,6 @@
 ## 1.4.x
 
 - Api pagination
-- Test case gap highlight in case of direct mapping
 - By default sort api by name, library_version instead of by id
 
 ## 1.3.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BASIL"
-version = "1.4.2"
+version = "1.4.3"
 description = "open source software quality management tool"
 authors = [
     {name = "Luigi Pellecchia", email = "lpellecc@redhat.com"},


### PR DESCRIPTION
Gap was already hihglited in the section coverage on the left side of the mapping