### PR TITLE
Show and manage unmapped Document. Fix Api updates.

### DIFF
--- a/app/src/app/Dashboard/Modal/APICheckSpecModal.tsx
+++ b/app/src/app/Dashboard/Modal/APICheckSpecModal.tsx
@@ -35,6 +35,9 @@ export const CheckSpecResults: React.FunctionComponent<checkSpecResultsProps> = 
   const [showJustificationsOk, setShowJustificationsOk] = React.useState(false)
   const [showJustificationsKo, setShowJustificationsKo] = React.useState(false)
   const [showJustificationsWarning, setShowJustificationsWarning] = React.useState(false)
+  const [showDocumentsOk, setShowDocumentsOk] = React.useState(false)
+  const [showDocumentsKo, setShowDocumentsKo] = React.useState(false)
+  const [showDocumentsWarning, setShowDocumentsWarning] = React.useState(false)
 
   React.useEffect(() => {
     setShowSwRequirementsOk(false)
@@ -49,6 +52,9 @@ export const CheckSpecResults: React.FunctionComponent<checkSpecResultsProps> = 
     setShowJustificationsOk(false)
     setShowJustificationsKo(false)
     setShowJustificationsWarning(false)
+    setShowDocumentsOk(false)
+    setShowDocumentsKo(false)
+    setShowDocumentsWarning(false)
 
     if (checkResultData['sw-requirements']['ok'].length > 0) {
       setShowSwRequirementsOk(true)
@@ -88,6 +94,16 @@ export const CheckSpecResults: React.FunctionComponent<checkSpecResultsProps> = 
     }
     if (checkResultData['justifications']['warning'].length > 0) {
       setShowJustificationsWarning(true)
+    }
+
+    if (checkResultData['documents']['ok'].length > 0) {
+      setShowDocumentsOk(true)
+    }
+    if (checkResultData['documents']['ko'].length > 0) {
+      setShowDocumentsKo(true)
+    }
+    if (checkResultData['documents']['warning'].length > 0) {
+      setShowDocumentsWarning(true)
     }
   }, [checkResultData])
 
@@ -176,6 +192,28 @@ export const CheckSpecResults: React.FunctionComponent<checkSpecResultsProps> = 
           ))}
           {showJustificationsWarning ? <DescriptionListTerm> * WARNING</DescriptionListTerm> : <span></span>}
           {checkResultData['justifications']['warning'].map((item, index) => (
+            <DescriptionListDescription key={index}>
+              {item.id} - {item.title}
+            </DescriptionListDescription>
+          ))}
+        </DescriptionListGroup>
+
+        <DescriptionListGroup>
+          <DescriptionListTerm>Documents</DescriptionListTerm>
+          {showDocumentsOk ? <DescriptionListTerm> * OK</DescriptionListTerm> : <span></span>}
+          {checkResultData['documents']['ok'].map((item, index) => (
+            <DescriptionListDescription key={index}>
+              {item.id} - {item.title}
+            </DescriptionListDescription>
+          ))}
+          {showDocumentsKo ? <DescriptionListTerm> * KO</DescriptionListTerm> : <span></span>}
+          {checkResultData['documents']['ko'].map((item, index) => (
+            <DescriptionListDescription key={index}>
+              {item.id} - {item.title}
+            </DescriptionListDescription>
+          ))}
+          {showDocumentsWarning ? <DescriptionListTerm> * WARNING</DescriptionListTerm> : <span></span>}
+          {checkResultData['documents']['warning'].map((item, index) => (
             <DescriptionListDescription key={index}>
               {item.id} - {item.title}
             </DescriptionListDescription>

--- a/app/src/app/Mapping/Mapping.tsx
+++ b/app/src/app/Mapping/Mapping.tsx
@@ -14,7 +14,7 @@ const Mapping: React.FunctionComponent = () => {
   const [apiData, setApiData] = React.useState(null)
   const [mappingData, setMappingData] = React.useState([])
   const [unmappingData, setUnmappingData] = React.useState([])
-  const [totalCoverage, setTotalCoverage] = React.useState(0)
+  const [totalCoverage, setTotalCoverage] = React.useState(-1)
   const { api_id } = useParams<{ api_id: string }>()
 
   //view
@@ -88,10 +88,16 @@ const Mapping: React.FunctionComponent = () => {
     if (mappingData == null) {
       return
     }
+    if (mappingData.length == 0) {
+      return
+    }
     let total_len = 0
     let wa = 0
     for (let i = 0; i < mappingData['length']; i++) {
       total_len = total_len + mappingData[i]['section']['length']
+    }
+    if (total_len == 0) {
+      return
     }
     for (let i = 0; i < mappingData['length']; i++) {
       wa = wa + (mappingData[i]['section']['length'] / total_len) * (mappingData[i]['covered'] / 100.0)
@@ -101,6 +107,12 @@ const Mapping: React.FunctionComponent = () => {
   }, [mappingData])
 
   const updateLastCoverage = (new_coverage) => {
+    if (apiData == null) {
+      return
+    }
+    if (new_coverage == apiData['last_coverage']) {
+      return
+    }
     let data = { 'api-id': api_id, 'last-coverage': new_coverage }
 
     if (auth.isLogged()) {

--- a/app/src/app/Mapping/MappingListingTable.tsx
+++ b/app/src/app/Mapping/MappingListingTable.tsx
@@ -102,8 +102,8 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
   const auth = useAuth()
 
   const getWorkItemDescription = (_work_item_type) => {
-    const work_item_types = [Constants._A, Constants._J, Constants._SR, Constants._TS, Constants._TC]
-    const work_item_descriptions = [Constants._A, Constants._J, 'Software Requirement', 'Test Specification', 'Test Case']
+    const work_item_types = [Constants._A, Constants._J, Constants._D, Constants._SR, Constants._TS, Constants._TC]
+    const work_item_descriptions = [Constants._A, Constants._J, Constants._D, 'Software Requirement', 'Test Specification', 'Test Case']
     return work_item_descriptions[work_item_types.indexOf(_work_item_type)]
   }
 
@@ -829,6 +829,10 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
       work_item_type = Constants._J
       work_item_description = snippet[Constants._J]['description']
       work_item_id = snippet[Constants._J]['id']
+    } else if (Object.prototype.hasOwnProperty.call(snippet, 'document')) {
+      work_item_type = Constants._D
+      work_item_description = snippet[Constants._D]['title']
+      work_item_id = snippet[Constants._D]['id']
     } else if (Object.prototype.hasOwnProperty.call(snippet, 'sw_requirement')) {
       work_item_type = Constants._SR
       work_item_description = snippet[Constants._SR_]['title']
@@ -867,6 +871,7 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
                   api={api}
                   srModalShowState={srModalShowState}
                   setDeleteModalInfo={setDeleteModalInfo}
+                  setDocModalInfo={setDocModalInfo}
                   setTcModalInfo={setTcModalInfo}
                   setTsModalInfo={setTsModalInfo}
                   setSrModalInfo={setSrModalInfo}

--- a/app/src/app/Mapping/Menu/UnmappedMenuKebab.tsx
+++ b/app/src/app/Mapping/Menu/UnmappedMenuKebab.tsx
@@ -9,6 +9,7 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 export interface UnmappedMenuKebabProps {
   srModalShowState
   setDeleteModalInfo
+  setDocModalInfo
   setTcModalInfo
   setTsModalInfo
   setSrModalInfo
@@ -24,6 +25,7 @@ export interface UnmappedMenuKebabProps {
 
 export const UnmappedMenuKebab: React.FunctionComponent<UnmappedMenuKebabProps> = ({
   setDeleteModalInfo,
+  setDocModalInfo,
   setTcModalInfo,
   setTsModalInfo,
   setSrModalInfo,
@@ -60,6 +62,13 @@ export const UnmappedMenuKebab: React.FunctionComponent<UnmappedMenuKebabProps> 
       //list = list_item;
       //list = mappingList[mappingIndex]
       setJModalInfo(true, 'edit', api, mappingSection, mappingOffset, mappingList, mappingIndex)
+    } else if (mappingType == Constants._D) {
+      //list_item = mappingList[mappingIndex];
+      //list_item['coverage'] = mappingList[mappingIndex]['coverage'];
+      //list_item['relation_id'] = mappingList[mappingIndex]['relation_id'];
+      //list = [list_item];
+      //list = mappingList[mappingIndex]
+      setDocModalInfo(true, 'edit', api, mappingSection, mappingOffset, mappingList, mappingIndex)
     } else if (mappingType == Constants._SR) {
       //list_item = mappingList[mappingIndex];
       //list_item['coverage'] = mappingList[mappingIndex]['coverage'];

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 - Api pagination
 - By default sort api by name, library_version instead of by id
+- Show and manage unmapped Document
+- Avoid to increate the api version on case of last_coverage (field used as cached coverage value) changes
+- Fix warning of Document work items
 
 ## 1.3.x
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BASIL"
-version = "1.4.3"
+version = "1.4.4"
 description = "open source software quality management tool"
 authors = [
     {name = "Luigi Pellecchia", email = "lpellecc@redhat.com"},


### PR DESCRIPTION
Show and manage unmapped Document. 
Avoid to increate the api version on case of last_coverage (field used as cached coverage value) changes. 
Fix warning of Document work items.