### PR TITLE
Moving basil.db to db/sqlite3

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -13,14 +13,14 @@ It is possible to use a different type of database configuring the SQLAlchemy **
 
 The database is not shipped with the source code because can be generated running a python script.
 
-To generate the default empty **db/basil.db** database:
+To generate the default empty **db/sqlite3/basil.db** database:
 
 ```sh
 
 # Move to the db/models directory
 cd db && cd models
 
-# Initialize the sqlite database, you will find it in db/basil.db
+# Initialize the sqlite database, you will find it in db/sqlite3/basil.db
 pdm run python3 init_db.py
 
 ```

--- a/db/db_orm.py
+++ b/db/db_orm.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
@@ -6,11 +6,12 @@ from sqlalchemy import create_engine
 
 class DbInterface():
 
-    engine = None
-    session = None
+    DB_TYPE = "sqlite3"
 
     def __init__(self, db_name="basil.db"):
         currentdir = os.path.dirname(os.path.realpath(__file__))
-        self.engine = create_engine(f"sqlite:///{currentdir}/{db_name}", echo=False)
+        if not os.path.exists(os.path.join(currentdir, self.DB_TYPE)):
+            os.mkdir(os.path.join(currentdir, self.DB_TYPE))
+        self.engine = create_engine(f"sqlite:///{currentdir}/{self.DB_TYPE}/{db_name}", echo=False)
         Session = sessionmaker(bind=self.engine)
         self.session = Session()

--- a/db/models/init_db.py
+++ b/db/models/init_db.py
@@ -42,10 +42,8 @@ def initialization(db_name='basil.db'):
         if os.path.exists(db_path):
             os.unlink(db_path)
 
-    engine = create_engine(f"sqlite:///{db_path}", echo=True)
-    Base.metadata.create_all(bind=engine)
-
     dbi = db_orm.DbInterface(db_name)
+    Base.metadata.create_all(bind=dbi.engine)
 
     if os.getenv('BASIL_ADMIN_PASSWORD', '') != '':
         admin_count = dbi.session.query(UserModel).filter(

--- a/docs/source/e2e_testing.rst
+++ b/docs/source/e2e_testing.rst
@@ -17,7 +17,7 @@ From BASIL project root directory:
    pdm run api/api.py --testing
 
 
-That will create a test database **db/test.db** preventing the modification of your production db **db/basil.db**
+That will create a test database **db/test.db** preventing the modification of your production db **db/sqlite3/basil.db**
 
 
 -----------

--- a/docs/source/how_to_run_it.rst
+++ b/docs/source/how_to_run_it.rst
@@ -149,7 +149,7 @@ You can copy the db file locally with the following docker command:
 
 .. code-block:: bash
 
-   docker cp basil-api-container:/BASIL-API/db/basil.db </YOUR/LOCAL/LOCATION>
+   docker cp basil-api-container:/BASIL-API/db/sqlite3/basil.db </YOUR/LOCAL/LOCATION>
 
 # Stop Containers
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Moving basil.db to db/sqlite3 to avoid issues with db/models updating BASIL to new versions. Refers to #62