### PR TITLE
Extends spdx export to other work items and switch to SPDX Model3

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -3,14 +3,14 @@
 FROM node:16
 USER root
 RUN mkdir BASIL-APP
-COPY . /BASIL-APP
-WORKDIR /BASIL-APP/app
+COPY ./app /BASIL-APP
+WORKDIR /BASIL-APP
 # Set the public ip
 ARG API_ENDPOINT=http://localhost:5000
 ARG APP_PORT=9000
 RUN sed -i "s#http://localhost:5000#${API_ENDPOINT}#g" src/app/Constants/constants.tsx && \
-    sed -i "s#--port 9000#--port ${APP_PORT}#g" package.json && \
-    npm install -d --verbose
+    sed -i "s#--port 9000#--port ${APP_PORT}#g" package.json
+RUN npm install -d --verbose
 RUN npm run build
 
 # In case of reverse proxy

--- a/api/spdx_manager.py
+++ b/api/spdx_manager.py
@@ -1,36 +1,149 @@
 import datetime
 import hashlib
 import json
+import os
+import sys
 
-from spdx_tools.spdx.model import (Checksum, ChecksumAlgorithm, CreationInfo, Document, File, FileType, Relationship,
-                                   RelationshipType, Snippet)
-from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
-from spdx_tools.spdx.writer.write_anything import write_file
+from semantic_version import Version
+from spdx_tools.spdx3.model.positive_integer_range import PositiveIntegerRange
+from spdx_tools.spdx3.payload import Payload
+from spdx_tools.spdx3.model import (
+    Hash,
+    HashAlgorithm,
+    CreationInfo,
+    ProfileIdentifierType,
+    Relationship,
+    RelationshipCompleteness,
+    RelationshipType,
+    SpdxDocument)
+from spdx_tools.spdx3.model.software import File, Snippet
+from spdx_tools.spdx3.writer.json_ld import json_ld_writer
+from typing import List
 
-from db import db_orm
-from db.models.api import ApiModel
-from db.models.api_justification import ApiJustificationModel
-from db.models.api_sw_requirement import ApiSwRequirementModel
-from db.models.api_test_case import ApiTestCaseModel
-from db.models.api_test_specification import ApiTestSpecificationModel
-from db.models.sw_requirement_sw_requirement import SwRequirementSwRequirementModel
-from db.models.sw_requirement_test_case import SwRequirementTestCaseModel
-from db.models.sw_requirement_test_specification import SwRequirementTestSpecificationModel
-from db.models.test_specification_test_case import TestSpecificationTestCaseModel
+currentdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(1, os.path.dirname(currentdir))
+
+from db import db_orm  # noqa E402
+from db.models.api import ApiModel  # noqa E402
+from db.models.api_document import ApiDocumentModel  # noqa E402
+from db.models.api_justification import ApiJustificationModel  # noqa E402
+from db.models.api_sw_requirement import ApiSwRequirementModel  # noqa E402
+from db.models.api_test_case import ApiTestCaseModel  # noqa E402
+from db.models.api_test_specification import ApiTestSpecificationModel  # noqa E402
+from db.models.sw_requirement_sw_requirement import SwRequirementSwRequirementModel  # noqa E402
+from db.models.sw_requirement_test_case import SwRequirementTestCaseModel  # noqa E402
+from db.models.sw_requirement_test_specification import SwRequirementTestSpecificationModel  # noqa E402
+from db.models.test_run import TestRunModel  # noqa E402
+from db.models.test_specification_test_case import TestSpecificationTestCaseModel  # noqa E402
 
 
 class SPDXManager():
 
     document = None
 
-    def __init__(self, document_name):
-        ci = CreationInfo(spdx_id=document_name,
-                          spdx_version="",
-                          name=document_name,
-                          document_namespace=document_name,
-                          creators=[],
+    API_REFERENCE_DOC_SPDX_ID_PREFIX = "API-REFERENCE-DOCUMENT"
+    API_SPDX_ID_PREFIX = "API"
+    DOCUMENT_SPDX_ID_PREFIX = "DOCUMENT"
+    JUSTIFICATION_SPDX_ID_PREFIX = "JUSTIFICATION"
+    SW_REQUIREMENT_SPDX_ID_PREFIX = "SW-REQUIREMENT"
+    TEST_CASE_SPDX_ID_PREFIX = "TEST-CASE"
+    TEST_RUN_SPDX_ID_PREFIX = "TEST-RUN"
+    TEST_SPECIFICATION_SPDX_ID_PREFIX = "TEST-SPECIFICATION"
+
+    def __init__(self, library_name):
+        spdx_id = f"SPDX-{library_name.strip()}-EXPORT"
+        ci = CreationInfo(spec_version=Version(version_string="1.0.0"),
+                          profile=[ProfileIdentifierType.SOFTWARE],
+                          created_by=["BASIL"],
                           created=datetime.datetime.now())
-        self.document = Document(ci)
+        self.document = SpdxDocument(creation_info=ci,
+                                     spdx_id=spdx_id,
+                                     element=[],
+                                     root_element=[],
+                                     name=library_name)
+        self.payload = Payload()
+        self.payload.add_element(self.document)
+
+    def add_files_to_payload(self, _files: List[File]):
+        """Add a File to Payload if not already there"""
+        for _file in _files:
+            existing = [f for f in self.payload.get_full_map().keys() if f == _file.spdx_id]
+            if not existing:
+                self.payload.add_element(_file)
+
+    def get_relationship_from_str(self, _relationship_str: str) -> RelationshipType:
+        """Convert a string to a RelationshipType
+
+        In the db we save the relationship as string.
+
+        :param _relationship_str: string of the relationship type
+        :return: RelationshipType related to the relationship string or OTHER
+        """
+        relationship_string_mapping = {
+            "AFFECTS": RelationshipType.AFFECTS,
+            "AMENDS": RelationshipType.AMENDS,
+            "ANCESTOR": RelationshipType.ANCESTOR,
+            "AVAILABLE_FROM": RelationshipType.AVAILABLE_FROM,
+            "BUILD_DEPENDENCY": RelationshipType.BUILD_DEPENDENCY,
+            "BUILD_TOOL": RelationshipType.BUILD_TOOL,
+            "COORDINATED_BY": RelationshipType.COORDINATED_BY,
+            "CONTAINS": RelationshipType.CONTAINS,
+            "CONFIG_OF": RelationshipType.CONFIG_OF,
+            "COPY": RelationshipType.COPY,
+            "DATA_FILE": RelationshipType.DATA_FILE,
+            "DEPENDENCY_MANIFEST": RelationshipType.DEPENDENCY_MANIFEST,
+            "DEPENDS_ON": RelationshipType.DEPENDS_ON,
+            "DESCENDANT": RelationshipType.DESCENDANT,
+            "DESCRIBES": RelationshipType.DESCRIBES,
+            "DEV_DEPENDENCY": RelationshipType.DEV_DEPENDENCY,
+            "DEV_TOOL": RelationshipType.DEV_TOOL,
+            "DISTRIBUTION_ARTIFACT": RelationshipType.DISTRIBUTION_ARTIFACT,
+            "DOCUMENTATION": RelationshipType.DOCUMENTATION,
+            "DOES_NOT_AFFECT": RelationshipType.DOES_NOT_AFFECT,
+            "DYNAMIC_LINK": RelationshipType.DYNAMIC_LINK,
+            "EXAMPLE": RelationshipType.EXAMPLE,
+            "EVIDENCE_FOR": RelationshipType.EVIDENCE_FOR,
+            "EXPANDED_FROM_ARCHIVE": RelationshipType.EXPANDED_FROM_ARCHIVE,
+            "EXPLOIT_CREATED_BY": RelationshipType.EXPLOIT_CREATED_BY,
+            "FILE_ADDED": RelationshipType.FILE_ADDED,
+            "FILE_DELETED": RelationshipType.FILE_DELETED,
+            "FILE_MODIFIED": RelationshipType.FILE_MODIFIED,
+            "FIXED_BY": RelationshipType.FIXED_BY,
+            "FIXED_IN": RelationshipType.FIXED_IN,
+            "FOUND_BY": RelationshipType.FOUND_BY,
+            "GENERATES": RelationshipType.GENERATES,
+            "HAS_ASSESSMENT_FOR": RelationshipType.HAS_ASSESSMENT_FOR,
+            "HAS_ASSOCIATED_VULNERABILITY": RelationshipType.HAS_ASSOCIATED_VULNERABILITY,
+            "HOST_OF": RelationshipType.HOST_OF,
+            "INPUT_OF": RelationshipType.INPUT_OF,
+            "INVOKED_BY": RelationshipType.INVOKED_BY,
+            "METAFILE": RelationshipType.METAFILE,
+            "ON_BEHALF_OF": RelationshipType.ON_BEHALF_OF,
+            "OPTIONAL_COMPONENT": RelationshipType.OPTIONAL_COMPONENT,
+            "OPTIONAL_DEPENDENCY": RelationshipType.OPTIONAL_DEPENDENCY,
+            "OTHER": RelationshipType.OTHER,
+            "OUTPUT_OF": RelationshipType.OUTPUT_OF,
+            "PACKAGES": RelationshipType.PACKAGES,
+            "PATCH": RelationshipType.PATCH,
+            "PREREQUISITE": RelationshipType.PREREQUISITE,
+            "PROVIDED_DEPENDENCY": RelationshipType.PROVIDED_DEPENDENCY,
+            "PUBLISHED_BY": RelationshipType.PUBLISHED_BY,
+            "REPORTED_BY": RelationshipType.REPORTED_BY,
+            "REPUBLISHED_BY": RelationshipType.REPUBLISHED_BY,
+            "REQUIREMENT_FOR": RelationshipType.REQUIREMENT_FOR,
+            "RUNTIME_DEPENDENCY": RelationshipType.RUNTIME_DEPENDENCY,
+            "SPECIFICATION_FOR": RelationshipType.SPECIFICATION_FOR,
+            "STATIC_LINK": RelationshipType.STATIC_LINK,
+            "TEST": RelationshipType.TEST,
+            "TEST_CASE": RelationshipType.TEST_CASE,
+            "TEST_DEPENDENCY": RelationshipType.TEST_DEPENDENCY,
+            "TEST_TOOL": RelationshipType.TEST_TOOL,
+            "TESTED_ON": RelationshipType.TESTED_ON,
+            "TRAINED_ON": RelationshipType.TRAINED_ON,
+            "UNDER_INVESTIGATION_FOR": RelationshipType.UNDER_INVESTIGATION_FOR,
+            "VARIANT": RelationshipType.VARIANT,
+        }
+        return relationship_string_mapping.get(_relationship_str, RelationshipType.OTHER)
 
     def dict_hash(self, dictionary) -> str:
         """MD5 hash of a dictionary."""
@@ -41,142 +154,149 @@ class SPDXManager():
         dhash.update(encoded)
         return dhash.hexdigest()
 
-    def ApiSwRequirementSPDX(self, _asr, _dbsession):
-        asr_dict = _asr.as_dict(full_data=True, db_session=_dbsession)
-        tmp = Snippet(spdx_id=f"SNIPPET-API-SR-{asr_dict['relation_id']}",
-                      comment="Software Requirement mapping a Snippet of Software Specification",
-                      file_spdx_id=asr_dict['api']['raw_specification_url'],
-                      byte_range=(asr_dict['offset'], asr_dict['offset'] + len(asr_dict['section'])),
-                      name=f"Sw Requirement {asr_dict['sw_requirement']['id']} mapping "
-                      f"Api snippet {asr_dict['relation_id']}",
-                      attribution_texts=[f"section: {asr_dict['section']}",
-                                         f"offset: {asr_dict['offset']}",
-                                         f"coverage: {asr_dict['coverage']}",
-                                         f"version: {asr_dict['version']}",
-                                         f"created_at: {asr_dict['updated_at']}"])
-        return tmp
+    def clean_api_relation_dict(self, relation_dict):
+        """Remove unwanted keys from a dictionary of a relation to api"""
+        unwanted_keys = ["api", "document", "justification", "sw_requirement", "test_case", "test_specification"]
+        for key in unwanted_keys:
+            if key in relation_dict.keys():
+                relation_dict.pop(key, None)
+        return relation_dict
 
-    def ApiTestSpecificationSPDX(self, _ats, _dbsession):
-        ats_dict = _ats.as_dict(full_data=True, db_session=_dbsession)
+    def get_completeness(self, coverage: int) -> RelationshipCompleteness:
+        """Return RelationshipCompleteness based on the mapping coverage percentage"""
+        if coverage >= 100:
+            return RelationshipCompleteness.COMPLETE
+        else:
+            return RelationshipCompleteness.INCOMPLETE
 
-        tmp = Snippet(spdx_id=f"SNIPPET-API-TS-{ats_dict['relation_id']}",
-                      comment="Test Specification mapping a Snippet of Software Specification",
-                      file_spdx_id=ats_dict['api']['raw_specification_url'],
-                      byte_range=(ats_dict['offset'], ats_dict['offset'] + len(ats_dict['section'])),
-                      name=f"Test Specification {ats_dict['test_specification']['id']} "
-                      f"mapping Api snippet {ats_dict['relation_id']}",
-                      attribution_texts=[f"section: {ats_dict['section']}",
-                                         f"offset: {ats_dict['offset']}",
-                                         f"coverage: {ats_dict['coverage']}",
-                                         f"version: {ats_dict['version']}",
-                                         f"created_at: {ats_dict['updated_at']}"])
-        return tmp
+    def SnippetSPDX(self, _mapping, _dbsession) -> Snippet:
+        """In BASIL, Software Component Reference Document are
+        split in Snippets and each Snippet is assigned to work items.
+        This function create SPDX Snippet class describing snippet of the reference document
+        """
+        mapping_from_id_prefix = self.API_SPDX_ID_PREFIX
+        mapping_to_id_prefix = ""
 
-    def ApiTestCaseSPDX(self, _atc, _dbsession):
-        atc_dict = _atc.as_dict(full_data=True, db_session=_dbsession)
+        if isinstance(_mapping, ApiDocumentModel):
+            mapping_to_id_prefix = self.DOCUMENT_SPDX_ID_PREFIX
+        elif isinstance(_mapping, ApiSwRequirementModel):
+            mapping_to_id_prefix = self.SW_REQUIREMENT_SPDX_ID_PREFIX
+        elif isinstance(_mapping, ApiTestSpecificationModel):
+            mapping_to_id_prefix = self.TEST_SPECIFICATION_SPDX_ID_PREFIX
+        elif isinstance(_mapping, ApiTestCaseModel):
+            mapping_to_id_prefix = self.TEST_CASE_SPDX_ID_PREFIX
+        elif isinstance(_mapping, ApiJustificationModel):
+            mapping_to_id_prefix = self.JUSTIFICATION_SPDX_ID_PREFIX
 
-        tmp = Snippet(spdx_id=f"SNIPPET-API-TC-{atc_dict['relation_id']}",
-                      comment="Test Case mapping a Snippet of Software Specification",
-                      file_spdx_id=atc_dict['api']['raw_specification_url'],
-                      byte_range=(atc_dict['offset'], atc_dict['offset'] + len(atc_dict['section'])),
-                      name=f"Test Case {atc_dict['test_case']['id']} mapping "
-                      f"Api snippet {atc_dict['relation_id']}",
-                      attribution_texts=[f"section: {atc_dict['section']}",
-                                         f"offset: {atc_dict['offset']}",
-                                         f"coverage: {atc_dict['coverage']}",
-                                         f"version: {atc_dict['version']}",
-                                         f"created_at:{atc_dict['updated_at']}"])
-        return tmp
+        mapping_dict = _mapping.as_dict(full_data=True, db_session=_dbsession)
+        api = mapping_dict['api']['api']
+        api_id = mapping_dict['api']['id']
+        relation_id = mapping_dict['relation_id']
+        mapping_dict = self.clean_api_relation_dict(mapping_dict)
 
-    def ApiJustificationSPDX(self, _js, _dbsession):
-        js_dict = _js.as_dict(full_data=True, db_session=_dbsession)
+        return Snippet(spdx_id=f"SNIPPET-{mapping_from_id_prefix}-"
+                               f"{mapping_to_id_prefix}-"
+                               f"{api_id}-"
+                               f"{relation_id}",
+                       name=f"Snippet of api {api} reference document",
+                       comment="",
+                       byte_range=PositiveIntegerRange(mapping_dict['offset'],
+                                                       mapping_dict['offset'] + len(mapping_dict['section'])),
+                       attribution_text=f"{mapping_dict}")
 
-        tmp = Snippet(spdx_id=f"SNIPPET-API-JUST-{js_dict['relation_id']}",
-                      comment="Justification mapping a Snippet of Software Specification",
-                      file_spdx_id=js_dict['api']['raw_specification_url'],
-                      byte_range=(js_dict['offset'], js_dict['offset'] + len(js_dict['section'])),
-                      name=f"Justification {js_dict['justification']['id']} mapping "
-                           f"Api snippet {js_dict['relation_id']}",
-                      attribution_texts=[f"section: {js_dict['section']}",
-                                         f"offset: {js_dict['offset']}",
-                                         f"version: {js_dict['version']}",
-                                         f"created_at: {js_dict['updated_at']}"])
-        return tmp
+    def ApiSPDX(self, _api, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Software Component"""
+        api_dict = _api.as_dict(full_data=True, db_session=_dbsession)
+        api_dict["__tablename__"] = _api.__tablename__
+        return File(spdx_id=f"{self.API_SPDX_ID_PREFIX}-{api_dict['id']}",
+                    name=f"{api_dict['api']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(api_dict))],
+                    attribution_text=f"{api_dict}",
+                    comment=_api._description)
 
-    def SwRequirementSPDX(self, _spdx_id, _sr, _dbsession):
+    def ApiReferenceDocumentSPDX(self, _api, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Software Component Reference Document"""
+        api_dict = _api.as_dict(full_data=True, db_session=_dbsession)
+        return File(spdx_id=f"{self.API_REFERENCE_DOC_SPDX_ID_PREFIX}-{api_dict['id']}",
+                    name=f"{api_dict['raw_specification_url']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(api_dict))],
+                    attribution_text=f"{api_dict}",
+                    comment=_api._description)
+
+    def SwRequirementSPDX(self, _sr, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Software Requirement"""
         sr_dict = _sr.as_dict(full_data=True, db_session=_dbsession)
+        sr_dict["__tablename__"] = _sr.__tablename__
+        return File(spdx_id=f"{self.SW_REQUIREMENT_SPDX_ID_PREFIX}_{sr_dict['id']}",
+                    name=f"{sr_dict['title']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(sr_dict))],
+                    attribution_text=f"{sr_dict}",
+                    comment=_sr._description)
 
-        tmp = File(spdx_id=_spdx_id,
-                   name=f"{sr_dict['title']}",
-                   checksums=[Checksum(ChecksumAlgorithm.MD5, self.dict_hash(sr_dict))],
-                   attribution_texts=[f"id: {sr_dict['id']}",
-                                      f"title: {sr_dict['title']}",
-                                      f"description: {sr_dict['description']}",
-                                      f"version: {sr_dict['version']}",
-                                      f"created_at: {sr_dict['updated_at']}",],
-                   file_types=[FileType.TEXT],
-                   comment="Software Requirement")
-        return tmp
-
-    def TestSpecificationSPDX(self, _spdx_id, _ts, _dbsession):
+    def TestSpecificationSPDX(self, _ts, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Test Specification"""
         ts_dict = _ts.as_dict(full_data=True, db_session=_dbsession)
-        print(f"ts_dict: {ts_dict}")
-        tmp = File(spdx_id=_spdx_id,
-                   name=f"{ts_dict['title']}",
-                   checksums=[Checksum(ChecksumAlgorithm.MD5, self.dict_hash(ts_dict))],
-                   attribution_texts=[f"id: {ts_dict['id']}",
-                                      f"title: {ts_dict['title']}",
-                                      f"test_description: {ts_dict['test_description']}",
-                                      f"preconditions: {ts_dict['preconditions']}",
-                                      f"expected_behavior: {ts_dict['expected_behavior']}",
-                                      f"version: {ts_dict['version']}",
-                                      f"created_at: {ts_dict['updated_at']}"],
-                   file_types=[FileType.TEXT],
-                   comment="Test Specification")
-        return tmp
+        ts_dict["__tablename__"] = _ts.__tablename__
+        return File(spdx_id=f"{self.TEST_SPECIFICATION_SPDX_ID_PREFIX}_{ts_dict['id']}",
+                    name=f"{ts_dict['title']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(ts_dict))],
+                    attribution_text=f"{ts_dict}",
+                    comment=_ts._description)
 
-    def TestCaseSPDX(self, _spdx_id, _tc, _dbsession):
+    def TestCaseSPDX(self, _tc, _mapping_to_prefix, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Test Case"""
         tc_dict = _tc.as_dict(full_data=True, db_session=_dbsession)
+        tc_dict["__tablename__"] = _tc.__tablename__
+        return File(spdx_id=f"{self.TEST_CASE_SPDX_ID_PREFIX}@{_mapping_to_prefix}_{tc_dict['id']}",
+                    name=f"{tc_dict['title']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(tc_dict))],
+                    attribution_text=f"{tc_dict}",
+                    comment=_tc._description)
 
-        tmp = File(spdx_id=_spdx_id,
-                   name=f"{tc_dict['title']}",
-                   checksums=[Checksum(ChecksumAlgorithm.MD5, self.dict_hash(tc_dict))],
-                   attribution_texts=[f"id: {tc_dict['id']}",
-                                      f"title: {tc_dict['title']}",
-                                      f"description: {tc_dict['description']}",
-                                      f"repository: {tc_dict['repository']}",
-                                      f"relative_path: {tc_dict['relative_path']}",
-                                      f"version: {tc_dict['version']}",
-                                      f"created_at: {tc_dict['updated_at']}"],
-                   file_types=[FileType.TEXT],
-                   comment="Test Case")
-        return tmp
+    def TestRunSPDX(self, _tr, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Test Run"""
+        tr_dict = _tr.as_dict(full_data=True)
+        tr_dict["__tablename__"] = _tr.__tablename__
+        return File(spdx_id=f"{self.TEST_RUN_SPDX_ID_PREFIX}_{tr_dict['id']}",
+                    name=f"{tr_dict['title']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(tr_dict))],
+                    attribution_text=f"{tr_dict}",
+                    comment=_tr._description)
 
-    def JustificationSPDX(self, _spdx_id, _js, _dbsession):
+    def JustificationSPDX(self, _js, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Justification"""
         js_dict = _js.as_dict(full_data=True, db_session=_dbsession)
+        js_dict["__tablename__"] = _js.__tablename__
+        return File(spdx_id=f"{self.JUSTIFICATION_SPDX_ID_PREFIX}_{js_dict['id']}",
+                    name=f"{js_dict['description']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(js_dict))],
+                    attribution_text=f"{js_dict}",
+                    comment=_js._description)
 
-        tmp = File(spdx_id=_spdx_id,
-                   name=f"{js_dict['description']}",
-                   checksums=[Checksum(ChecksumAlgorithm.MD5, self.dict_hash(js_dict))],
-                   attribution_texts=[f"id: {js_dict['id']}",
-                                      f"description: {js_dict['description']}",
-                                      f"version: {js_dict['version']}",
-                                      f"created_at: {js_dict['updated_at']}"],
-                   file_types=[FileType.TEXT],
-                   comment="Justification")
-        return tmp
+    def DocumentSPDX(self, _doc, _dbsession) -> File:
+        """This function create SPDX File class describing a BASIL Document"""
+        doc_dict = _doc.as_dict(full_data=True, db_session=_dbsession)
+        doc_dict["__tablename__"] = _doc.__tablename__
+        return File(spdx_id=f"{self.DOCUMENT_SPDX_ID_PREFIX}_{doc_dict['id']}",
+                    name=f"{doc_dict['title']}",
+                    verified_using=[Hash(algorithm=HashAlgorithm.MD5, hash_value=self.dict_hash(doc_dict))],
+                    attribution_text=f"{doc_dict}",
+                    comment=_doc._description)
 
-    def get_x_sr_children(self, xsr, dbi):
-
+    def get_x_sr_children(self, xsr, spdx_sr, dbi):
+        """In BASIL user can create a complex hierarchy of Software Requirements.
+        Moreover we can assign other work items to each Software Requirement in the chain.
+        This method navigate the hierarchy and return all the work items
+        """
         files = []
         relationships = []
 
         if isinstance(xsr, ApiSwRequirementModel):
             mapping_field_id = 'sw_requirement_mapping_api_id'
-            mapping_spdx_id = 'API'
+            api_id = xsr.api_id
         elif isinstance(xsr, SwRequirementSwRequirementModel):
             mapping_field_id = 'sw_requirement_mapping_sw_requirement_id'
-            mapping_spdx_id = 'SR'
+            api_id = xsr.sw_requirement_mapping_api.api.id
         else:
             return files, relationships
 
@@ -185,15 +305,17 @@ class SPDXManager():
             getattr(SwRequirementSwRequirementModel, mapping_field_id) == xsr.id
         ).all()
         for sr_sr in sr_srs:
-            spdx_sr_id = f'SR-SR-{sr_sr.id}'
-            spdx_sr = self.SwRequirementSPDX(spdx_sr_id, sr_sr.sw_requirement, dbi.session)
-            sr_sr_rel = Relationship(f"{mapping_spdx_id}-SR-{xsr.id}",
-                                     RelationshipType.REQUIREMENT_DESCRIPTION_FOR,
-                                     spdx_sr_id)
-            files += [spdx_sr]
-            relationships += [sr_sr_rel]
+            spdx_sr_sr = self.SwRequirementSPDX(sr_sr.sw_requirement, dbi.session)
+            spdx_sr_sr_rel = Relationship(spdx_id=f"REL_{spdx_sr.spdx_id}_{spdx_sr_sr.spdx_id}",
+                                          from_element=spdx_sr.spdx_id,
+                                          completeness=self.get_completeness(sr_sr.coverage),
+                                          relationship_type=RelationshipType.GENERATES,
+                                          to=[spdx_sr_sr.spdx_id])
 
-            child_files, child_relationships = self.get_x_sr_children(sr_sr, dbi)
+            files += [spdx_sr_sr]
+            relationships += [spdx_sr_sr_rel]
+
+            child_files, child_relationships = self.get_x_sr_children(sr_sr, spdx_sr_sr, dbi)
             files += child_files
             relationships += child_relationships
 
@@ -202,166 +324,242 @@ class SPDXManager():
             getattr(SwRequirementTestSpecificationModel, mapping_field_id) == xsr.id
         ).all()
         for sr_ts in sr_tss:
-            spdx_ts_id = f"SR-TS-{sr_ts.id}"
-            spdx_ts = self.TestSpecificationSPDX(spdx_ts_id, sr_ts.test_specification, dbi.session)
-            asr_ts_rel = Relationship(spdx_ts_id,
-                                      RelationshipType.TEST_OF,
-                                      f"{mapping_spdx_id}-SR-{xsr.id}")
+            spdx_ts = self.TestSpecificationSPDX(sr_ts.test_specification, dbi.session)
+            spdx_sr_ts_rel = Relationship(spdx_id=f"REL_{spdx_ts.spdx_id}_{spdx_sr.spdx_id}",
+                                          from_element=spdx_ts.spdx_id,
+                                          completeness=self.get_completeness(sr_ts.coverage),
+                                          relationship_type=RelationshipType.TEST,
+                                          to=[spdx_sr.spdx_id])
             files += [spdx_ts]
-            relationships += [asr_ts_rel]
+            relationships += [spdx_sr_ts_rel]
 
             # TestSpecificationTestCaseModel
             ts_tcs = dbi.session.query(TestSpecificationTestCaseModel).filter(
                 TestSpecificationTestCaseModel.test_specification_mapping_sw_requirement_id == sr_ts.id
             ).all()
             for ts_tc in ts_tcs:
-                spdx_tc_id = f"TS-TC-{ts_tc.id}"
-                spdx_tc = self.TestCaseSPDX(spdx_tc_id, ts_tc.test_case, dbi.session)
-                ts_tc_rel = Relationship(f"SR-TS-{sr_ts.id}",
-                                         RelationshipType.SPECIFICATION_FOR,
-                                         spdx_tc_id)
+                spdx_tc = self.TestCaseSPDX(ts_tc.test_case,
+                                            self.TEST_SPECIFICATION_SPDX_ID_PREFIX,
+                                            dbi.session)
+                spdx_ts_tc_rel = Relationship(spdx_id=f"REL_{spdx_ts.spdx_id}_{spdx_tc.spdx_id}",
+                                              from_element=spdx_ts.spdx_id,
+                                              completeness=self.get_completeness(ts_tc.coverage),
+                                              relationship_type=RelationshipType.SPECIFICATION_FOR,
+                                              to=[spdx_tc.spdx_id])
                 files += [spdx_tc]
-                relationships += [ts_tc_rel]
+                relationships += [spdx_ts_tc_rel]
+
+                # Test Runs
+                spdx_trs, spdx_trs_rel = self.get_test_runs(api_id, ts_tc, spdx_tc, dbi)
+                files += spdx_trs
+                relationships += spdx_trs_rel
 
         # SwRequirementTestCaseModel
         sr_tcs = dbi.session.query(SwRequirementTestCaseModel).filter(
             getattr(SwRequirementTestCaseModel, mapping_field_id) == xsr.id
         ).all()
         for sr_tc in sr_tcs:
-            spdx_tc_id = f'SR-TC-{sr_tc.id}'
-            spdx_tc = self.TestCaseSPDX(spdx_tc_id, sr_tc.test_case, dbi.session)
-            xsr_tc_rel = Relationship(spdx_tc_id,
-                                      RelationshipType.TEST_CASE_OF,
-                                      f"{mapping_spdx_id}-SR-{xsr.id}")
+            spdx_tc = self.TestCaseSPDX(sr_tc.test_case,
+                                        self.SW_REQUIREMENT_SPDX_ID_PREFIX,
+                                        dbi.session)
+            spdx_sr_tc_rel = Relationship(spdx_id=f"REL_{spdx_tc.spdx_id}_{spdx_sr.spdx_id}",
+                                          from_element=spdx_tc.spdx_id,
+                                          completeness=self.get_completeness(sr_tc.coverage),
+                                          relationship_type=RelationshipType.TEST_CASE,
+                                          to=[spdx_sr.spdx_id])
             files += [spdx_tc]
-            relationships += [xsr_tc_rel]
+            relationships += [spdx_sr_tc_rel]
+
+            # Test Runs
+            spdx_trs, spdx_trs_rel = self.get_test_runs(api_id, sr_tc, spdx_tc, dbi)
+            files += spdx_trs
+            relationships += spdx_trs_rel
 
         return files, relationships
 
-    def add_api_to_export(self, api_id):
-        dbi = db_orm.DbInterface()
-        api = dbi.session.query(ApiModel).filter(ApiModel.id == api_id).one()
+    def get_test_runs(self, api_id, mapping_model_instance, spdx_tc, dbi):
+        """List Test Run for a selected mapping_model_instance and api_id and return
+        list of TestRunSPDX and list of Relationship to Test Case
 
-        api_sw_requirements = dbi.session.query(ApiSwRequirementModel).filter(
-            ApiSwRequirementModel.api_id == api_id
+        Note: Same Test Case can be mapped to different section of the Reference Document
+        or to different work items. BASIL Test Runs refers to the mapping ot the Test Case, not to
+        the Test Case itself.
+        """
+        trs = dbi.session.query(TestRunModel).filter(
+            TestRunModel.api_id == api_id,
+            TestRunModel.mapping_to == mapping_model_instance.__tablename__,
+            TestRunModel.mapping_id == mapping_model_instance.id,
         ).all()
 
-        spdx_api = File(spdx_id=f"API-{api.id}",
-                        comment="Software Component",
-                        checksums=[Checksum(ChecksumAlgorithm.MD5, self.dict_hash(api.as_dict()))],
-                        name=f"{api.api}",
-                        attribution_texts=[f"category: {api.category}",
-                                           f"library: {api.library}",
-                                           f"library_version: {api.library_version}",
-                                           f"implementation_file: {api.implementation_file}",
-                                           f"implementation_file_from_row: {api.implementation_file_from_row}",
-                                           f"implementation_file_to_row: {api.implementation_file_to_row}",
-                                           f"raw_specification_url: {api.raw_specification_url}",
-                                           f"tags: {api.tags}",
-                                           f"created_at: {api.created_at}"],
-                        file_types=[FileType.TEXT],
-                        )
+        spdx_trs = []
+        spdx_trs_rel = []
 
-        self.document.files += [spdx_api]
+        for tr in trs:
+            spdx_tr = self.TestRunSPDX(tr, dbi.session)
+            spdx_tr_rel = Relationship(spdx_id=f"REL_{spdx_tr.spdx_id}_{spdx_tc.spdx_id}",
+                                       from_element=spdx_tr.spdx_id,
+                                       relationship_type=RelationshipType.EVIDENCE_FOR,
+                                       to=[spdx_tc.spdx_id])
+            spdx_trs.append(spdx_tr)
+            spdx_trs_rel.append(spdx_tr_rel)
+        return spdx_trs, spdx_trs_rel
+
+    def add_api_to_export(self, api: ApiModel):
+        """Collect all the work items of a BASIL Software Component and their relationships
+        and add them to the class payload"""
+        dbi = db_orm.DbInterface()
+        api = dbi.session.query(ApiModel).filter(ApiModel.id == api.id).one()
+
+        # Api
+        spdx_api = self.ApiSPDX(api, dbi.session)
+        spdx_api_ref_doc = self.ApiReferenceDocumentSPDX(api, dbi.session)
+        api_api_ref_doc_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_api.spdx_id}",
+                                           from_element=spdx_api_ref_doc.spdx_id,
+                                           relationship_type=RelationshipType.DESCRIBES,
+                                           to=[spdx_api.spdx_id])
+
+        self.add_files_to_payload([spdx_api, spdx_api_ref_doc])
+        self.add_files_to_payload([api_api_ref_doc_rel])
 
         # ApiSwRequirement
+        api_sw_requirements = dbi.session.query(ApiSwRequirementModel).filter(
+            ApiSwRequirementModel.api_id == api.id
+        ).all()
         for asr in api_sw_requirements:
             # ApiSwRequirement
-            spdx_asr_id = f'API-SR-{asr.id}'
-            spdx_asr = self.ApiSwRequirementSPDX(asr, dbi.session)
-            api_asr_rel = Relationship(f"API-{api.id}",
-                                       RelationshipType.GENERATES,
-                                       f'SNIPPET-API-SR-{asr.id}')
-            spdx_sr = self.SwRequirementSPDX(spdx_asr_id, asr.sw_requirement, dbi.session)
-            asr_sr_rel = Relationship(spdx_asr_id,
-                                      RelationshipType.REQUIREMENT_DESCRIPTION_FOR,
-                                      f'SNIPPET-API-SR-{asr.id}')
+            spdx_asr_snippet = self.SnippetSPDX(asr, dbi.session)
+            spdx_asr_snippet_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_asr_snippet.spdx_id}",
+                                                from_element=spdx_api_ref_doc.spdx_id,
+                                                relationship_type=RelationshipType.CONTAINS,
+                                                to=[spdx_asr_snippet.spdx_id])
+            spdx_sr = self.SwRequirementSPDX(asr.sw_requirement, dbi.session)
+            spdx_asr_sr_rel = Relationship(spdx_id=f"REL_{spdx_sr.spdx_id}_{spdx_asr_snippet.spdx_id}",
+                                           from_element=spdx_sr.spdx_id,
+                                           completeness=self.get_completeness(asr.coverage),
+                                           relationship_type=RelationshipType.REQUIREMENT_FOR,
+                                           to=[spdx_asr_snippet.spdx_id])
 
-            self.document.snippets += [spdx_asr]
-            self.document.files += [spdx_sr]
-            self.document.relationships += [api_asr_rel, asr_sr_rel]
+            self.add_files_to_payload([spdx_asr_snippet])
+            self.add_files_to_payload([spdx_sr])
+            self.add_files_to_payload([spdx_asr_snippet_rel, spdx_asr_sr_rel])
 
-            child_files, child_relationships = self.get_x_sr_children(asr, dbi)
-            self.document.files += child_files
-            self.document.relationships += child_relationships
+            child_files, child_relationships = self.get_x_sr_children(asr, spdx_sr, dbi)
+            self.add_files_to_payload(child_files)
+            self.add_files_to_payload(child_relationships)
 
         # ApiTestSpecification
         api_test_specifications = dbi.session.query(ApiTestSpecificationModel).filter(
-            ApiTestSpecificationModel.api_id == api_id
+            ApiTestSpecificationModel.api_id == api.id
         ).all()
         for ats in api_test_specifications:
-            spdx_ats_id = f'API-TS-{ats.id}'
-            spdx_ats = self.ApiTestSpecificationSPDX(ats, dbi.session)
-            api_ats_rel = Relationship(f"API-{api.id}",
-                                       RelationshipType.GENERATES,
-                                       f"SNIPPET-API-TS-{ats.id}")
-            spdx_ts = self.TestSpecificationSPDX(spdx_ats_id, ats.test_specification, dbi.session)
-            ats_ts_rel = Relationship(spdx_ats_id,
-                                      RelationshipType.TEST_OF,
-                                      f"SNIPPET-API-TS-{ats.id}")
+            spdx_ats_snippet = self.SnippetSPDX(ats, dbi.session)
+            spdx_ats_snippet_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_ats_snippet.spdx_id}",
+                                                from_element=spdx_api_ref_doc.spdx_id,
+                                                relationship_type=RelationshipType.CONTAINS,
+                                                to=[spdx_ats_snippet.spdx_id])
+            spdx_ts = self.TestSpecificationSPDX(ats.test_specification, dbi.session)
+            spdx_ats_ts_rel = Relationship(spdx_id=f"REL_{spdx_ts.spdx_id}_{spdx_ats_snippet.spdx_id}",
+                                           from_element=spdx_ts.spdx_id,
+                                           completeness=self.get_completeness(ats.coverage),
+                                           relationship_type=RelationshipType.TEST,
+                                           to=[spdx_ats_snippet.spdx_id])
+
+            self.add_files_to_payload([spdx_ats_snippet])
+            self.add_files_to_payload([spdx_ts])
+            self.add_files_to_payload([spdx_ats_snippet_rel, spdx_ats_ts_rel])
 
             # TestSpecificationTestCase
             ts_tcs = dbi.session.query(TestSpecificationTestCaseModel).filter(
                 TestSpecificationTestCaseModel.test_specification_mapping_api_id == ats.id
             ).all()
             for ts_tc in ts_tcs:
-                spdx_tc_id = f'TS-TC-{ts_tc.id}'
-                spdx_tc = self.TestCaseSPDX(spdx_tc_id, ts_tc.test_case, dbi.session)
-                ts_tc_rel = Relationship(spdx_ats_id,
-                                         RelationshipType.SPECIFICATION_FOR,
-                                         spdx_tc_id)
-                self.document.files += [spdx_tc]
-                self.document.relationships += [ts_tc_rel]
+                spdx_tc = self.TestCaseSPDX(ts_tc.test_case,
+                                            self.TEST_SPECIFICATION_SPDX_ID_PREFIX,
+                                            dbi.session)
+                spdx_ts_tc_rel = Relationship(spdx_id=f"REL_{spdx_ts.spdx_id}_{spdx_tc.spdx_id}",
+                                              from_element=spdx_ts.spdx_id,
+                                              completeness=self.get_completeness(ts_tc.coverage),
+                                              relationship_type=RelationshipType.SPECIFICATION_FOR,
+                                              to=[spdx_tc.spdx_id])
+                self.add_files_to_payload([spdx_tc])
+                self.add_files_to_payload([spdx_ts_tc_rel])
 
-            self.document.snippets += [spdx_ats]
-            self.document.files += [spdx_ts]
-            self.document.relationships += [api_ats_rel]
-            self.document.relationships += [ats_ts_rel]
+                # Test Runs
+                spdx_trs, spdx_trs_rel = self.get_test_runs(api.id, ts_tc, spdx_tc, dbi)
+                self.add_files_to_payload(spdx_trs)
+                self.add_files_to_payload(spdx_trs_rel)
 
         # ApiTestCase
         api_test_cases = dbi.session.query(ApiTestCaseModel).filter(
-            ApiTestCaseModel.api_id == api_id
+            ApiTestCaseModel.api_id == api.id
         ).all()
         for atc in api_test_cases:
-            spdx_atc_id = f'API-TC-{atc.id}'
-            spdx_atc = self.ApiTestCaseSPDX(atc, dbi.session)
-            api_atc_rel = Relationship(f"API-{api.id}",
-                                       RelationshipType.GENERATES,
-                                       f"SNIPPET-API-TC-{atc.id}")
-            spdx_tc = self.TestCaseSPDX(spdx_atc_id, atc.test_case, dbi.session)
-            atc_tc_rel = Relationship(spdx_atc_id,
-                                      RelationshipType.TEST_CASE_OF,
-                                      f"SNIPPET-API-TC-{atc.id}")
+            spdx_atc_snippet = self.SnippetSPDX(atc, dbi.session)
+            spdx_atc_snippet_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_atc_snippet.spdx_id}",
+                                                from_element=spdx_api_ref_doc.spdx_id,
+                                                relationship_type=RelationshipType.CONTAINS,
+                                                to=[spdx_atc_snippet.spdx_id])
+            spdx_tc = self.TestCaseSPDX(atc.test_case,
+                                        self.API_SPDX_ID_PREFIX,
+                                        dbi.session)
+            spdx_atc_tc_rel = Relationship(spdx_id=f"REL_{spdx_tc.spdx_id}_{spdx_atc_snippet.spdx_id}",
+                                           from_element=spdx_tc.spdx_id,
+                                           completeness=self.get_completeness(atc.coverage),
+                                           relationship_type=RelationshipType.TEST_CASE,
+                                           to=[spdx_atc_snippet.spdx_id])
 
-            self.document.snippets += [spdx_atc]
-            self.document.files += [spdx_tc]
-            self.document.relationships += [api_atc_rel, atc_tc_rel]
+            self.add_files_to_payload([spdx_atc_snippet])
+            self.add_files_to_payload([spdx_tc])
+            self.add_files_to_payload([spdx_atc_snippet_rel, spdx_atc_tc_rel])
+
+            # Test Runs
+            spdx_trs, spdx_trs_rel = self.get_test_runs(api.id, atc, spdx_tc, dbi)
+            self.add_files_to_payload(spdx_trs)
+            self.add_files_to_payload(spdx_trs_rel)
 
         # ApiJustification
         api_justifications = dbi.session.query(ApiJustificationModel).filter(
-            ApiJustificationModel.api_id == api_id
+            ApiJustificationModel.api_id == api.id
         ).all()
         for aj in api_justifications:
-            spdx_aj_id = f"API-JUST-{aj.id}"
-            spdx_aj = self.ApiJustificationSPDX(aj, dbi.session)
-            api_js_rel = Relationship(f"API-{api.id}",
-                                      RelationshipType.GENERATES,
-                                      f"SNIPPET-API-JUST-{aj.id}")
-            spdx_j = self.JustificationSPDX(spdx_aj_id, aj.justification, dbi.session)
-            aj_j_rel = Relationship(spdx_aj_id,
-                                    RelationshipType.DESCRIBES,
-                                    f"SNIPPET-API-JUST-{aj.id}")
+            spdx_aj_snippet = self.SnippetSPDX(aj, dbi.session)
+            spdx_aj_snippet_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_aj_snippet.spdx_id}",
+                                               from_element=spdx_api_ref_doc.spdx_id,
+                                               relationship_type=RelationshipType.CONTAINS,
+                                               to=[spdx_aj_snippet.spdx_id])
+            spdx_j = self.JustificationSPDX(aj.justification, dbi.session)
+            spdx_aj_j_rel = Relationship(spdx_id=f"REL_{spdx_j.spdx_id}_{spdx_aj_snippet.spdx_id}",
+                                         from_element=spdx_j.spdx_id,
+                                         completeness=self.get_completeness(aj.coverage),
+                                         relationship_type=RelationshipType.DESCRIBES,
+                                         to=[spdx_aj_snippet.spdx_id])
 
-            self.document.snippets += [spdx_aj]
-            self.document.files += [spdx_j]
-            self.document.relationships += [api_js_rel, aj_j_rel]
+            self.add_files_to_payload([spdx_aj_snippet])
+            self.add_files_to_payload([spdx_j])
+            self.add_files_to_payload([spdx_aj_snippet_rel, spdx_aj_j_rel])
+
+        # ApiDocument
+        api_documents = dbi.session.query(ApiDocumentModel).filter(
+            ApiDocumentModel.api_id == api.id
+        ).all()
+        for adoc in api_documents:
+            spdx_adoc_snippet = self.SnippetSPDX(adoc, dbi.session)
+            spdx_adoc_snippet_rel = Relationship(spdx_id=f"REL_{spdx_api_ref_doc.spdx_id}_{spdx_adoc_snippet.spdx_id}",
+                                                 from_element=spdx_api_ref_doc.spdx_id,
+                                                 relationship_type=RelationshipType.CONTAINS,
+                                                 to=[spdx_adoc_snippet.spdx_id])
+            spdx_doc = self.DocumentSPDX(adoc.document, dbi.session)
+            spdx_adoc_doc_rel = Relationship(spdx_id=f"REL_{spdx_doc.spdx_id}_{spdx_adoc_snippet.spdx_id}",
+                                             from_element=spdx_doc.spdx_id,
+                                             completeness=self.get_completeness(adoc.coverage),
+                                             relationship_type=self.get_relationship_from_str(
+                                                 adoc.document.spdx_relation),
+                                             to=[spdx_adoc_snippet.spdx_id])
+
+            self.add_files_to_payload([spdx_adoc_snippet])
+            self.add_files_to_payload([spdx_doc])
+            self.add_files_to_payload([spdx_adoc_snippet_rel, spdx_adoc_doc_rel])
 
     def export(self, filepath):
-        validation_messages = validate_full_spdx_document(self.document)
-        for validation_message in validation_messages:
-            print(validation_message.validation_message)
-
-        # if there are no validation messages, the document is valid
-        # and we can safely serialize it without validating again
-        # if not validation_messages:
-        write_file(self.document, filepath, validate=False)
+        """Export payload into json"""
+        json_ld_writer.write_payload(self.payload, filepath)

--- a/app/src/app/Mapping/MappingPageSection.tsx
+++ b/app/src/app/Mapping/MappingPageSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Constants from '../Constants/constants'
 import { Button, Card, CardBody, Flex, FlexItem, PageSection, Title } from '@patternfly/react-core'
+import { APIExportSPDXModal } from '../Dashboard/Modal/APIExportSPDXModal'
 import { MappingListingTable } from './MappingListingTable'
 import { MappingSwRequirementModal } from './Modal/MappingSwRequirementModal'
 import { MappingTestSpecificationModal } from './Modal/MappingTestSpecificationModal'
@@ -55,6 +56,9 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
   const [modalSection, setModalSection] = React.useState('')
   const [modalOffset, setModalOffset] = React.useState('')
 
+  const [modalSPDXExportShowState, setModalSPDXExportShowState] = React.useState(false)
+  const [SPDXContent, setSPDXContent] = React.useState('')
+
   const [srModalShowState, setSrModalShowState] = React.useState<boolean>(false)
   const [tsModalShowState, setTsModalShowState] = React.useState<boolean>(false)
   const [tcModalShowState, setTcModalShowState] = React.useState<boolean>(false)
@@ -84,6 +88,18 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
   const [showIndirectTestSpecifications, setShowIndirectTestSpecifications] = React.useState<boolean>(true)
   const [showIndirectTestCasesOld, setShowIndirectTestCasesOld] = React.useState<boolean>(true)
   const [showIndirectTestCases, setShowIndirectTestCases] = React.useState<boolean>(true)
+
+  const exportSPDX = () => {
+    fetch(Constants.API_BASE_URL + '/spdx/apis?id=' + api.id)
+      .then((res) => res.json())
+      .then((data) => {
+        setSPDXContent(JSON.stringify(data, null, 2))
+        setModalSPDXExportShowState(true)
+      })
+      .catch((err) => {
+        console.log(err.message)
+      })
+  }
 
   const getWorkItemDescription = (_work_item_type) => {
     const work_item_types = [Constants._A, Constants._D, Constants._J, Constants._SR, Constants._TS, Constants._TC]
@@ -382,6 +398,11 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
               </Flex>
               {api?.permissions?.indexOf('w') >= 0 ? (
                 <Flex align={{ default: 'alignRight' }}>
+                  <FlexItem>
+                    <Button id='btn-export-sw-component-to-spdx' variant='secondary' onClick={() => exportSPDX()}>
+                      Export to SPDX
+                    </Button>
+                  </FlexItem>
                   <FlexItem>
                     <Button
                       variant='secondary'
@@ -685,6 +706,12 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
         modalShowState={testRunModalShowState}
         modalRelationData={modalRelationData}
         parentType={modalParentType}
+      />
+      <APIExportSPDXModal
+        SPDXContent={SPDXContent}
+        setSPDXContent={setSPDXContent}
+        modalShowState={modalSPDXExportShowState}
+        setModalShowState={setModalSPDXExportShowState}
       />
     </React.Fragment>
   )

--- a/db/models/api.py
+++ b/db/models/api.py
@@ -13,6 +13,7 @@ from typing import Optional
 class ApiModel(Base):
     __tablename__ = "apis"
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = "Software Component"
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/document.py
+++ b/db/models/document.py
@@ -13,6 +13,7 @@ from typing import Optional
 class DocumentModel(Base):
     __tablename__ = 'documents'
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Document'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/justification.py
+++ b/db/models/justification.py
@@ -13,6 +13,7 @@ from typing import Optional
 class JustificationModel(Base):
     __tablename__ = 'justifications'
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Justification'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/sw_requirement.py
+++ b/db/models/sw_requirement.py
@@ -13,6 +13,7 @@ from typing import Optional
 class SwRequirementModel(Base):
     __tablename__ = 'sw_requirements'
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Software Requirement'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/test_case.py
+++ b/db/models/test_case.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import relationship
 class TestCaseModel(Base):
     __tablename__ = "test_cases"
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Test Case'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/test_run.py
+++ b/db/models/test_run.py
@@ -15,6 +15,7 @@ import uuid
 class TestRunModel(Base):
     __tablename__ = "test_runs"
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Test Run'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/test_run_config.py
+++ b/db/models/test_run_config.py
@@ -13,6 +13,7 @@ from typing import Optional
 class TestRunConfigModel(Base):
     __tablename__ = "test_run_configs"
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Test Run Configuration'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/db/models/test_specification.py
+++ b/db/models/test_specification.py
@@ -13,6 +13,7 @@ from typing import Optional
 class TestSpecificationModel(Base):
     __tablename__ = 'test_specifications'
     __table_args__ = {"sqlite_autoincrement": True}
+    _description = 'Test Specification'
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gunicorn==21.2.0
 pyaml-env==1.2.1
 python-gitlab==3.15.0
 requests==2.28.2
-spdx-tools==0.8.1
+spdx-tools==0.8.3
 tmt==1.31.0
 tmt[provision-container]
 Werkzeug==2.2.2


### PR DESCRIPTION
This MR is related to #63 and #64 
Extend spdx export to Document and Test Run.
Migrate to SPDX model3
UI change to export to SPDX from within a software component (not only from an entire library)