### PR TITLE
Implement import of Software Requirements from json file exported from BASIL

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -3614,7 +3614,7 @@ class SwRequirementImport(Resource):
             return BAD_REQUEST_MESSAGE, BAD_REQUEST_STATUS
 
         spdx_importer = SPDXImport()
-        return spdx_importer.getBasilSwRequirementsToSelect(request_data["file_content"])
+        return {_SRs: spdx_importer.getBasilSwRequirementsToSelect(request_data["file_content"])}
 
     def put(self):
         request_data = request.get_json(force=True)
@@ -3644,9 +3644,9 @@ class SwRequirementImport(Resource):
         if sw_requirements:
             dbi.session.add_all(sw_requirements)
             dbi.session.commit()
-            return [sr.as_dict() for sr in sw_requirements]
+            return {_SRs: [sr.as_dict() for sr in sw_requirements]}
 
-        return []
+        return {_SRs: []}
 
 
 class Justification(Resource):

--- a/app/src/app/Mapping/Import/SwRequirementImport.tsx
+++ b/app/src/app/Mapping/Import/SwRequirementImport.tsx
@@ -142,11 +142,11 @@ export const SwRequirementImport: React.FunctionComponent = () => {
       })
       .then((data) => {
         const reqs: SwRequirement[] = []
-        for (let i = 0; i < data.length; i++) {
+        for (let i = 0; i < data['sw_requirements'].length; i++) {
           const req: SwRequirement = {
-            id: data[i].id,
-            title: data[i].title,
-            description: data[i].description
+            id: data['sw_requirements'][i].id,
+            title: data['sw_requirements'][i].title,
+            description: data['sw_requirements'][i].description
           }
           reqs.push(req)
         }

--- a/app/src/app/Mapping/Import/SwRequirementImport.tsx
+++ b/app/src/app/Mapping/Import/SwRequirementImport.tsx
@@ -1,0 +1,287 @@
+import * as React from 'react'
+import * as Constants from '../../Constants/constants'
+import { DropEvent, FileUpload } from '@patternfly/react-core'
+import { ActionGroup, Button, Hint, HintBody } from '@patternfly/react-core'
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
+import { useAuth } from '../../User/AuthProvider'
+
+interface SwRequirement {
+  id: string
+  title: string
+  description: string
+}
+
+export const SwRequirementImport: React.FunctionComponent = () => {
+  const auth = useAuth()
+  const importUrl = Constants.API_BASE_URL + '/import/sw-requirements'
+  const [messageValue, setMessageValue] = React.useState('')
+  const [statusValue, setStatusValue] = React.useState('waiting')
+
+  // Table
+  const [SwRequirements, setSwRequirements] = React.useState<SwRequirement[]>([])
+
+  const [selectedRowsIds, setSelectedRowsIds] = React.useState<string[]>([])
+  const areAllRowsSelected = selectedRowsIds.length === SwRequirements.length
+  const [shifting, setShifting] = React.useState(false)
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<number | null>(null)
+  const isRowSelected = (id) => selectedRowsIds.includes(id)
+
+  const setRowSelected = (row: SwRequirement, isSelecting = true) =>
+    setSelectedRowsIds((prevSelected) => {
+      const otherSelectedRowsIds = prevSelected.filter((r) => r !== row.id)
+      return isSelecting ? [...otherSelectedRowsIds, row.id] : otherSelectedRowsIds
+    })
+
+  const onSelectRow = (row: SwRequirement, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex)
+      intermediateIndexes.forEach((index) => setRowSelected(SwRequirements[index], isSelecting))
+    } else {
+      setRowSelected(row, isSelecting)
+    }
+    setRecentSelectedRowIndex(rowIndex)
+    setMessageValue('')
+  }
+
+  const selectAllRows = (isSelecting = true) => setSelectedRowsIds(isSelecting ? SwRequirements.map((r) => r.id) : [])
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true)
+      }
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('keyup', onKeyUp)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('keyup', onKeyUp)
+    }
+  }, [])
+
+  // File Upload
+  const [fileContent, setFileContent] = React.useState('')
+  const [fileName, setFileName] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const handleFileInputChange = (_, file: File) => {
+    setFileName(file.name)
+  }
+
+  const handleTextChange = (_event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => {
+    setFileContent(value)
+  }
+
+  const handleDataChange = (_event: DropEvent, value: string) => {
+    setFileContent(value)
+  }
+
+  const handleClear = () => {
+    setFileName('')
+    setFileContent('')
+    setMessageValue('Data erased')
+  }
+
+  const handleFileReadStarted = () => {
+    setIsLoading(true)
+  }
+
+  const handleFileReadFinished = () => {
+    setIsLoading(false)
+  }
+
+  const columnNames = {
+    id: 'ID',
+    title: 'Title',
+    description: 'Description'
+  }
+
+  const resetForm = () => {
+    setFileName('')
+    setFileContent('')
+    setSwRequirements([])
+    setSelectedRowsIds([])
+  }
+
+  React.useEffect(() => {
+    console.log(fileContent)
+    if (fileContent?.length > 0) {
+      getSwRequirementsList()
+    }
+  }, [fileContent])
+
+  const getSwRequirementsList = () => {
+    const data = { file_content: fileContent }
+    fetch(importUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    })
+      .then((res) => {
+        if (!res.ok) {
+          setMessageValue('Error loading data')
+          setSwRequirements([])
+          return {}
+        } else {
+          return res.json()
+        }
+      })
+      .then((data) => {
+        const reqs: SwRequirement[] = []
+        for (let i = 0; i < data.length; i++) {
+          const req: SwRequirement = {
+            id: data[i].id,
+            title: data[i].title,
+            description: data[i].description
+          }
+          reqs.push(req)
+        }
+        setSwRequirements(reqs)
+        if (setSwRequirements.length > 0) {
+          setMessageValue('Data loaded')
+        }
+      })
+      .catch((err) => {
+        console.log(err.message)
+        setMessageValue(err.message)
+        setSwRequirements([])
+      })
+  }
+
+  React.useEffect(() => {
+    if (statusValue == 'submitted') {
+      handleSubmit()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusValue])
+
+  const handleSubmit = () => {
+    if (selectedRowsIds.length == 0) {
+      setMessageValue('Please, select at least one row.')
+      return
+    }
+
+    setMessageValue('')
+
+    const data = {
+      file_content: fileContent,
+      filter_ids: selectedRowsIds.join(','),
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(importUrl, {
+      method: 'PUT',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        if (response.status !== 200) {
+          setMessageValue(response.statusText)
+          setStatusValue('waiting')
+        } else {
+          setStatusValue('waiting')
+          setMessageValue('Requirements imported!')
+          resetForm()
+        }
+      })
+      .catch((err) => {
+        setStatusValue('waiting')
+        setMessageValue(err.toString())
+      })
+  }
+
+  return (
+    <React.Fragment>
+      <FileUpload
+        id='sw-requirement-spdx-file-upload'
+        type='text'
+        hideDefaultPreview={true}
+        value={fileContent}
+        filename={fileName}
+        filenamePlaceholder='Drag and drop a file or upload one'
+        onFileInputChange={handleFileInputChange}
+        onDataChange={handleDataChange}
+        onTextChange={handleTextChange}
+        onReadStarted={handleFileReadStarted}
+        onReadFinished={handleFileReadFinished}
+        onClearClick={handleClear}
+        isLoading={isLoading}
+        allowEditingUploadedText={false}
+        browseButtonText='Upload'
+      />
+      <br />
+      {fileContent && (
+        <Table aria-label='Selectable table'>
+          <Thead>
+            <Tr>
+              <Th
+                select={{
+                  onSelect: (_event, isSelecting) => selectAllRows(isSelecting),
+                  isSelected: areAllRowsSelected
+                }}
+                aria-label='Row select'
+              />
+              <Th>{columnNames.id}</Th>
+              <Th>{columnNames.title}</Th>
+              <Th>{columnNames.description}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {SwRequirements.map((sw_requirement, rowIndex) => (
+              <Tr key={rowIndex}>
+                <Td
+                  select={{
+                    rowIndex,
+                    onSelect: (_event, isSelecting) => onSelectRow(sw_requirement, rowIndex, isSelecting),
+                    isSelected: isRowSelected(sw_requirement.id)
+                  }}
+                />
+                <Td dataLabel={columnNames.id}>{sw_requirement.id}</Td>
+                <Td dataLabel={columnNames.title}>{sw_requirement.title}</Td>
+                <Td dataLabel={columnNames.description}>{sw_requirement.description}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+      <br />
+      {messageValue ? (
+        <>
+          <Hint>
+            <HintBody>{messageValue}</HintBody>
+          </Hint>
+          <br />
+        </>
+      ) : (
+        ''
+      )}
+
+      <ActionGroup>
+        <Button id='btn-mapping-existing-sw-requirement-submit' variant='primary' onClick={() => setStatusValue('submitted')}>
+          Submit
+        </Button>
+        <Button id='btn-mapping-existing-sw-requirement-cancel' variant='secondary' onClick={resetForm}>
+          Reset
+        </Button>
+      </ActionGroup>
+    </React.Fragment>
+  )
+}

--- a/app/src/app/Mapping/Modal/MappingSwRequirementModal.tsx
+++ b/app/src/app/Mapping/Modal/MappingSwRequirementModal.tsx
@@ -4,6 +4,7 @@ import * as Constants from '../../Constants/constants'
 import { SectionForm } from '../Form/SectionForm'
 import { SwRequirementForm } from '../Form/SwRequirementForm'
 import { SwRequirementSearch } from '../Search/SwRequirementSearch'
+import { SwRequirementImport } from '../Import/SwRequirementImport'
 
 export interface MappingSwRequirementModalProps {
   api
@@ -110,7 +111,7 @@ export const MappingSwRequirementModal: React.FunctionComponent<MappingSwRequire
             id='tab-btn-sw-requirement-data'
             eventKey={0}
             title={<TabTitleText>Sw Requirement Data</TabTitleText>}
-            tabContentId='tabNewTestCase'
+            tabContentId='tabNewSwRequirement'
             tabContentRef={newItemRef}
           />
           <Tab
@@ -126,7 +127,15 @@ export const MappingSwRequirementModal: React.FunctionComponent<MappingSwRequire
             eventKey={2}
             isDisabled={modalVerb == 'POST' ? false : true}
             title={<TabTitleText>Existing</TabTitleText>}
-            tabContentId='tabExistingTestCase'
+            tabContentId='tabExistingSwRequirement'
+            tabContentRef={existingItemsRef}
+          />
+          <Tab
+            id='tab-btn-sw-requirement-import'
+            eventKey={3}
+            isDisabled={false}
+            title={<TabTitleText>Import</TabTitleText>}
+            tabContentId='tabImportSwRequirement'
             tabContentRef={existingItemsRef}
           />
         </Tabs>
@@ -186,6 +195,11 @@ export const MappingSwRequirementModal: React.FunctionComponent<MappingSwRequire
                 formMessage={''}
                 formData={null}
               />
+            </TabContentBody>
+          </TabContent>
+          <TabContent eventKey={3} id='tabContentSwRequirementImport' ref={existingItemsRef} hidden={3 !== activeTabKey}>
+            <TabContentBody hasPadding>
+              <SwRequirementImport />
             </TabContentBody>
           </TabContent>
         </div>


### PR DESCRIPTION
Adding a software requirement now a new tab is available in the modal view "import"
From here a user can select a json file exported from a BASIL instance and all software requirements will be listed in a table.
Each row will have a checkbox that allow users to select which work items to import.
Once selected and submitted the requirements will be generated and they will be available in the "Existing" tab (need to click search to refresh the list of requirements at the moment).
NOTE: We don't validate if an identical requirement already exists at this moment before creating a new work item. That validation is done in the manual insert.