### PR TITLE
Fix Containerfiles

### DIFF
--- a/Containerfile-api-debian
+++ b/Containerfile-api-debian
@@ -2,13 +2,15 @@ FROM debian:12
 USER root
 RUN mkdir BASIL-API
 WORKDIR /BASIL-API
-COPY . .
 
 RUN apt update && apt install --assume-yes \
     curl git patch podman \
     python3 python3-pip python3-virtualenv \
-    rsync && \
-    virtualenv penv && \
+    rsync
+
+COPY . .
+
+RUN virtualenv penv && \
     . penv/bin/activate && \
     pip3 install --no-cache-dir -r requirements.txt
 

--- a/Containerfile-api-fedora
+++ b/Containerfile-api-fedora
@@ -2,12 +2,13 @@ FROM registry.fedoraproject.org/fedora:39
 USER root
 RUN mkdir BASIL-API
 WORKDIR /BASIL-API
-COPY api/ /BASIL-API/api
-COPY db/ /BASIL-API/db
-COPY misc/ /BASIL-API/misc
-COPY requirements.txt pyproject.toml /BASIL-API/
-RUN dnf install -y curl git patch python3 python3-pip podman rsync && \
-    pip3 install --no-cache-dir -r requirements.txt
+
+# Install dependencies
+RUN dnf install -y curl git patch python3 python3-pip podman rsync
+
+COPY . .
+
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set the public ip in the api/api_url.py
 ARG API_PORT=5000


### PR DESCRIPTION
fedora api container missed the examples folders. 
Moved the copy of the files after the installation of the required packages to speedup the container build during development.
Execute the installation of python packages after the copy of the files because it needs the requirements.txt file.