### PR TITLE
Triggering a new run we will be redirected to the Test Results modal view

### DIFF
--- a/app/src/app/Mapping/MappingListingTable.tsx
+++ b/app/src/app/Mapping/MappingListingTable.tsx
@@ -285,7 +285,7 @@ const MappingListingTable: React.FunctionComponent<MappingListingTableProps> = (
         console.log(err.message)
         return false
       })
-      return true
+    return true
   }
 
   const getTestCases = (section, offset, test_cases, indirect, parent_type, parent_related_to_type) => {

--- a/app/src/app/Mapping/MappingPageSection.tsx
+++ b/app/src/app/Mapping/MappingPageSection.tsx
@@ -703,6 +703,7 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
       <TestRunModal
         api={api}
         setModalShowState={setTestRunModalShowState}
+        setTestResultsModalShowState={setTestResultsModalShowState}
         modalShowState={testRunModalShowState}
         modalRelationData={modalRelationData}
         parentType={modalParentType}

--- a/app/src/app/Mapping/Modal/TestResultsModal.tsx
+++ b/app/src/app/Mapping/Modal/TestResultsModal.tsx
@@ -460,7 +460,7 @@ export const TestResultsModal: React.FunctionComponent<TestResultsModalProps> = 
         if (response.status !== 200) {
           setMessageValue(response.statusText)
         } else {
-          handleModalToggle()
+          loadTestResults()
           setMessageValue('')
         }
       })

--- a/app/src/app/Mapping/Modal/TestRunModal.tsx
+++ b/app/src/app/Mapping/Modal/TestRunModal.tsx
@@ -25,6 +25,7 @@ export interface TestRunModalProps {
   modalShowState: boolean
   parentType
   setModalShowState
+  setTestResultsModalShowState
 }
 
 export const TestRunModal: React.FunctionComponent<TestRunModalProps> = ({
@@ -32,7 +33,8 @@ export const TestRunModal: React.FunctionComponent<TestRunModalProps> = ({
   modalRelationData,
   modalShowState,
   parentType,
-  setModalShowState
+  setModalShowState,
+  setTestResultsModalShowState
 }: TestRunModalProps) => {
   const auth = useAuth()
   const [infoLabel, setInfoLabel] = React.useState('new')
@@ -300,6 +302,7 @@ export const TestRunModal: React.FunctionComponent<TestRunModalProps> = ({
           setMessageValue(response.statusText)
         } else {
           handleModalToggle()
+          setTestResultsModalShowState(true)
           setMessageValue('')
           resetForms()
         }


### PR DESCRIPTION
Triggering a new run (also re-running an existing one) we will be redirected to the Test Results modal view.
Refers to #89 