### PR TITLE
Reset password via email, user profile edit, admin settings

### DIFF
--- a/api/notifier.py
+++ b/api/notifier.py
@@ -1,0 +1,72 @@
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+import ssl
+import traceback
+
+
+class EmailNotifier():
+
+    settings = None
+
+    def __init__(self, settings):
+        """Init the class with the settings"""
+        self.settings = settings
+
+    def validate_settings(self) -> bool:
+        """Validate instance settings."""
+        smtp_mandatory_settings = ["from", "host", "password", "port", "user"]
+
+        if not self.settings:
+            print("Invalid settings")
+            return False
+
+        if "smtp" not in self.settings.keys():
+            return False
+
+        for setting in smtp_mandatory_settings:
+            if setting not in self.settings["smtp"]:
+                print(f"Field {setting} not in settings")
+                return False
+            else:
+                if not self.settings["smtp"][setting]:
+                    print(f"Setting field {setting} is not valid")
+                    return False
+                if str(self.settings["smtp"][setting]).strip() == "":
+                    print(f"Setting field {setting} is not valid")
+                    return False
+        return True
+
+    def send_email(self, recipient, subject, body, is_html=False):
+
+        if not self.validate_settings():
+            print("Settings not valid")
+            return False
+
+        try:
+            smtp_from = self.settings["smtp"]["from"]
+            smtp_host = self.settings["smtp"]["host"]
+            smtp_password = self.settings["smtp"]["password"]
+            smtp_port = self.settings["smtp"]["port"]
+            smtp_user = self.settings["smtp"]["user"]
+
+            msg = MIMEMultipart()
+            msg['From'] = smtp_from
+            msg['To'] = recipient
+            msg['Subject'] = subject
+
+            if is_html:
+                msg.attach(MIMEText(body, 'html'))
+            else:
+                msg.attach(MIMEText(body, 'plain'))
+
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            with smtplib.SMTP(smtp_host, smtp_port) as server:
+                server.starttls(context=context)
+                server.login(smtp_user, smtp_password)
+                server.send_message(msg)
+            return True
+        except Exception as e:
+            print(f"Error on send_email: {e}")
+            print(traceback.format_exc())
+            return False

--- a/api/settings.yaml
+++ b/api/settings.yaml
@@ -1,8 +1,7 @@
 app_url: http://localhost:9000
 smtp:
-  from: 'BASIL - The FuSa Spice'
-  host: ''
-  password: ''
+  from: "BASIL - The FuSa Spice"
+  host: ""
+  password: ""
   port: 0
-  user: ''
- 
+  user: ""

--- a/api/settings.yaml
+++ b/api/settings.yaml
@@ -1,0 +1,8 @@
+app_url: http://localhost:9000
+smtp:
+  from: 'BASIL - The FuSa Spice'
+  host: ''
+  password: ''
+  port: 0
+  user: ''
+ 

--- a/app/src/app/Admin/AdminSettings.tsx
+++ b/app/src/app/Admin/AdminSettings.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import * as Constants from '../Constants/constants'
+import { Button, Divider, Flex, FlexItem, Hint, HintBody, PageSection } from '@patternfly/react-core'
+import { Editor } from '@monaco-editor/react'
+import { useAuth } from '../User/AuthProvider'
+export interface AdminSettingsProps {}
+
+const AdminSettings: React.FunctionComponent = () => {
+  const [settingsContent, setSettingsContent] = React.useState('')
+  const [messageValue, setMessageValue] = React.useState('')
+  const auth = useAuth()
+  const ADMIN_SETTINGS_ENDPOINT = '/admin/settings'
+
+  const onChange = (value) => {
+    setSettingsContent(value)
+    setMessageValue('')
+  }
+
+  const onEditorDidMount = () => {
+    //
+    loadSettings()
+  }
+
+  const loadSettings = () => {
+    setMessageValue('')
+    setSettingsContent('')
+
+    let url = Constants.API_BASE_URL + ADMIN_SETTINGS_ENDPOINT
+    url += '?user-id=' + auth.userId
+    url += '&token=' + auth.token
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) {
+          setMessageValue('Error loading Settings')
+          return ''
+        } else {
+          return res.json()
+        }
+      })
+      .then((data) => {
+        setSettingsContent(data['content'])
+      })
+      .catch((err) => {
+        console.log(err.message)
+      })
+  }
+
+  const saveSettings = () => {
+    setMessageValue('')
+
+    const url = Constants.API_BASE_URL + ADMIN_SETTINGS_ENDPOINT
+    const data = { content: settingsContent, 'user-id': auth.userId, token: auth.token }
+    fetch(url, {
+      method: 'PUT',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        if (response.status !== 200) {
+          setMessageValue(response.statusText)
+        } else {
+          loadSettings()
+          setMessageValue('SAVED')
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+        console.log(err.toString())
+      })
+  }
+
+  return (
+    <PageSection isFilled>
+      <div>
+        {messageValue ? (
+          <>
+            <Divider />
+            <Hint>
+              <HintBody>{messageValue}</HintBody>
+            </Hint>
+            <br />
+          </>
+        ) : (
+          ''
+        )}
+      </div>
+
+      <Editor
+        language={'yaml'}
+        value={settingsContent}
+        onChange={onChange}
+        theme={'vs-dark'}
+        onMount={onEditorDidMount}
+        height='800px'
+        options={{
+          fontSize: 20
+        }}
+      />
+
+      <Divider />
+      <br />
+
+      <Flex>
+        <FlexItem>
+          <Button
+            onClick={() => {
+              loadSettings()
+            }}
+          >
+            Reload
+          </Button>
+        </FlexItem>
+        <FlexItem>
+          <Button
+            onClick={() => {
+              saveSettings()
+            }}
+          >
+            Save
+          </Button>
+        </FlexItem>
+      </Flex>
+    </PageSection>
+  )
+}
+
+export { AdminSettings }

--- a/app/src/app/Admin/Modal/AdminModal.tsx
+++ b/app/src/app/Admin/Modal/AdminModal.tsx
@@ -66,7 +66,7 @@ export const AdminModal: React.FunctionComponent<AdminModalProps> = ({
       password: base64_encode(newPassword)
     }
 
-    fetch(Constants.API_BASE_URL + '/user/reset-password', {
+    fetch(Constants.API_BASE_URL + Constants.API_ADMIN_RESET_USER_PASSWORD_ENDPOINT, {
       method: 'PUT',
       headers: Constants.JSON_HEADER,
       body: JSON.stringify(data)

--- a/app/src/app/AppLayout/AppLayout.tsx
+++ b/app/src/app/AppLayout/AppLayout.tsx
@@ -218,6 +218,16 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
             >
               Test Run Plugin Presets
             </NavItem>
+            <NavItem
+              preventDefault
+              id='nav-item-settings'
+              to='#nav-item-settings'
+              onClick={() => redirect('/settings')}
+              itemId='ungrouped-item-6'
+              isActive={location.pathname == '/settings'}
+            >
+              Settings
+            </NavItem>
           </>
         ) : (
           ''
@@ -230,7 +240,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
               id='nav-item-user-ssh-keys'
               to='#nav-item-user-ssh-keys'
               onClick={() => redirect('/ssh-keys')}
-              itemId='ungrouped-item-5'
+              itemId='ungrouped-item-7'
               isActive={location.pathname == '/ssh-keys'}
             >
               SSH Keys
@@ -240,7 +250,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
               id='nav-item-user-files'
               to='#nav-item-user-files'
               onClick={() => redirect('/user-files')}
-              itemId='ungrouped-item-6'
+              itemId='ungrouped-item-8'
               isActive={location.pathname == '/user-files'}
             >
               User Files

--- a/app/src/app/AppLayout/HeaderToolbar.tsx
+++ b/app/src/app/AppLayout/HeaderToolbar.tsx
@@ -55,10 +55,10 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
     setIsDropdownOpen(false)
   }
 
-  const modalProfileSetInfo = () => {
+  const modalProfileSetInfo = () => {
     setUserProfileModalShowState(true)
   }
-  
+
   /*
   const onKebabDropdownToggle = () => {
     setIsKebabDropdownOpen(!isKebabDropdownOpen)
@@ -158,58 +158,56 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
 
   return (
     <>
-    <Toolbar id='toolbar' isFullHeight isStatic>
-      <ToolbarContent>
-        <ToolbarGroup variant='icon-button-group' align={{ default: 'alignRight' }} spacer={{ default: 'spacerNone', md: 'spacerMd' }}>
-          <ToolbarItem>
-            <Button
-              aria-label='Notifications'
-              variant={ButtonVariant.plain}
-              icon={<BellIcon />}
-              onClick={toggleNotificationDrawer}
-              countOptions={badgeCountObjectNotRead}
-            />
-          </ToolbarItem>
-          <ToolbarGroup variant='icon-button-group' visibility={{ default: 'hidden', lg: 'visible' }}>
+      <Toolbar id='toolbar' isFullHeight isStatic>
+        <ToolbarContent>
+          <ToolbarGroup variant='icon-button-group' align={{ default: 'alignRight' }} spacer={{ default: 'spacerNone', md: 'spacerMd' }}>
             <ToolbarItem>
               <Button
-                component='a'
-                href='https://basil-the-fusa-spice.readthedocs.io/'
-                target='_blank'
-                aria-label='Help'
+                aria-label='Notifications'
                 variant={ButtonVariant.plain}
-                icon={<QuestionCircleIcon />}
+                icon={<BellIcon />}
+                onClick={toggleNotificationDrawer}
+                countOptions={badgeCountObjectNotRead}
               />
             </ToolbarItem>
+            <ToolbarGroup variant='icon-button-group' visibility={{ default: 'hidden', lg: 'visible' }}>
+              <ToolbarItem>
+                <Button
+                  component='a'
+                  href='https://basil-the-fusa-spice.readthedocs.io/'
+                  target='_blank'
+                  aria-label='Help'
+                  variant={ButtonVariant.plain}
+                  icon={<QuestionCircleIcon />}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
           </ToolbarGroup>
-        </ToolbarGroup>
-        <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
-          <Dropdown
-            isOpen={isDropdownOpen}
-            onSelect={onDropdownSelect}
-            onOpenChange={(isOpen: boolean) => setIsDropdownOpen(isOpen)}
-            popperProps={{ position: 'right' }}
-            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle
-                ref={toggleRef}
-                onClick={onDropdownToggle}
-                isFullHeight
-                isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt='' />}
-              >
-                {auth.isLogged() ? auth.userEmail : 'Guest'}
-              </MenuToggle>
-            )}
-          >
-            <DropdownList>{getUserDropdownItems()}</DropdownList>
-          </Dropdown>
-        </ToolbarItem>
-      </ToolbarContent>
-    </Toolbar>
+          <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
+            <Dropdown
+              isOpen={isDropdownOpen}
+              onSelect={onDropdownSelect}
+              onOpenChange={(isOpen: boolean) => setIsDropdownOpen(isOpen)}
+              popperProps={{ position: 'right' }}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={onDropdownToggle}
+                  isFullHeight
+                  isExpanded={isDropdownOpen}
+                  icon={<Avatar src={imgAvatar} alt='' />}
+                >
+                  {auth.isLogged() ? auth.userEmail : 'Guest'}
+                </MenuToggle>
+              )}
+            >
+              <DropdownList>{getUserDropdownItems()}</DropdownList>
+            </Dropdown>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
 
-    <UserProfileModal 
-      modalShowState={userProfileModalShowState}
-      setModalShowState={setUserProfileModalShowState} />
+      <UserProfileModal modalShowState={userProfileModalShowState} setModalShowState={setUserProfileModalShowState} />
     </>
   )
 }

--- a/app/src/app/AppLayout/HeaderToolbar.tsx
+++ b/app/src/app/AppLayout/HeaderToolbar.tsx
@@ -17,6 +17,7 @@ import {
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon'
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon'
 import imgAvatar from '../bgimages/avatarImg.svg'
+import { UserProfileModal } from '@app/User/Modal/UserProfileModal'
 import { useAuth } from '../User/AuthProvider'
 
 export interface HeaderToolbarProps {
@@ -32,6 +33,7 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
 }: HeaderToolbarProps) => {
   const auth = useAuth()
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
+  const [userProfileModalShowState, setUserProfileModalShowState] = React.useState(false)
   //const [isKebabDropdownOpen, setIsKebabDropdownOpen] = React.useState(false)
   //const [isFullKebabDropdownOpen, setIsFullKebabDropdownOpen] = React.useState(false)
 
@@ -53,6 +55,10 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
     setIsDropdownOpen(false)
   }
 
+  const modalProfileSetInfo = () => {
+    setUserProfileModalShowState(true)
+  }
+  
   /*
   const onKebabDropdownToggle = () => {
     setIsKebabDropdownOpen(!isKebabDropdownOpen)
@@ -73,6 +79,11 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
 
   const adminDropdownItems = (
     <>
+      <DropdownItem key='user profile'>
+        <Button variant='link' onClick={() => modalProfileSetInfo()}>
+          Profile
+        </Button>
+      </DropdownItem>
       <DropdownItem key='admin test run plugins presets'>
         <Button component='a' href='/plugins-presets' variant='link'>
           Test Run Plugins Presets
@@ -113,6 +124,11 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
 
   const userDropdownItems = (
     <>
+      <DropdownItem key='user profile'>
+        <Button variant='link' onClick={() => modalProfileSetInfo()}>
+          Profile
+        </Button>
+      </DropdownItem>
       <DropdownItem key='user ssh keys'>
         <Button component='a' href='/ssh-keys' variant='link'>
           SSH Keys
@@ -141,6 +157,7 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
   }
 
   return (
+    <>
     <Toolbar id='toolbar' isFullHeight isStatic>
       <ToolbarContent>
         <ToolbarGroup variant='icon-button-group' align={{ default: 'alignRight' }} spacer={{ default: 'spacerNone', md: 'spacerMd' }}>
@@ -189,6 +206,11 @@ const HeaderToolbar: React.FunctionComponent<HeaderToolbarProps> = ({
         </ToolbarItem>
       </ToolbarContent>
     </Toolbar>
+
+    <UserProfileModal 
+      modalShowState={userProfileModalShowState}
+      setModalShowState={setUserProfileModalShowState} />
+    </>
   )
 }
 

--- a/app/src/app/Constants/constants.tsx
+++ b/app/src/app/Constants/constants.tsx
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'http://localhost:5000'
+export const API_BASE_URL = 'http://localhost:5005' //'http://192.168.1.13:5000'
 export const TESTING_FARM_COMPOSES_URL = 'https://api.dev.testing-farm.io/v0.1/composes'
 export const force_reload = true
 
@@ -31,11 +31,15 @@ export const DEFAULT_PER_PAGE = 10
 export type validate = 'success' | 'warning' | 'error' | 'error2' | 'default' | 'indeterminate' | 'undefined'
 
 export const PATH_SEP = '/'
+export const API_USER_ENDPOINT = '/user'
 export const API_USER_APIS_ENDPOINT = '/user/apis'
 export const API_USER_PERMISSIONS_API_ENDPOINT = '/user/permissions/api'
 export const API_USER_PERMISSIONS_API_COPY_ENDPOINT = '/user/permissions/copy'
 export const API_USER_FILES_ENDPOINT = '/user/files'
 export const API_USER_FILES_CONTENT_ENDPOINT = '/user/files/content'
+export const API_USER_RESET_PASSWORD_ENDPOINT = '/user/reset-password'
+export const API_USER_SIGNIN_ENDPOINT = '/user/signin'
+export const API_ADMIN_RESET_USER_PASSWORD_ENDPOINT = '/admin/reset-user-password'
 
 export const JSON_HEADER = {
   Accept: 'application/json',
@@ -46,6 +50,19 @@ export const getMappingTableName = (workItemType: string, parentType: string) =>
   let parent_table = workItemType + _M_ + parentType
   parent_table = parent_table.replaceAll('-', '_')
   return parent_table
+}
+
+export const getSearchParamsDict = () => {
+  //Return a dictionary with key value based on search params querystring
+  let ret = {}
+  const search = window.location.search
+  const search_params = new URLSearchParams(search)
+  const params_keys = Array.from(search_params.keys())
+  const params_values = Array.from(search_params.values())
+  for (let i = 0; i < params_keys.length; i++) {
+    ret[params_keys[i]] = params_values[i]
+  }
+  return ret
 }
 
 export const validateCoverage = (coverage, setValidatedCoverage) => {

--- a/app/src/app/Constants/constants.tsx
+++ b/app/src/app/Constants/constants.tsx
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'http://localhost:5005' //'http://192.168.1.13:5000'
+export const API_BASE_URL = 'http://localhost:5000'
 export const TESTING_FARM_COMPOSES_URL = 'https://api.dev.testing-farm.io/v0.1/composes'
 export const force_reload = true
 

--- a/app/src/app/Login/Login.tsx
+++ b/app/src/app/Login/Login.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import logo from '@app/bgimages/basil.svg'
 import background_image from '@app/bgimages/background.svg'
-import { ListItem, ListVariant, LoginFooterItem, LoginForm, LoginMainFooterBandItem, LoginPage } from '@patternfly/react-core'
+import { Button, Icon, ListItem, ListVariant, LoginFooterItem, LoginForm, LoginMainFooterBandItem, LoginPage } from '@patternfly/react-core'
 import { Redirect, useLocation } from 'react-router-dom'
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon'
 import { useAuth } from '../User/AuthProvider'
+import * as Constants from '../Constants/constants'
 
 const Login: React.FunctionComponent = () => {
   const location = useLocation()
@@ -15,6 +16,17 @@ const Login: React.FunctionComponent = () => {
   const [isValidUsername, setIsValidUsername] = React.useState(true)
   const [password, setPassword] = React.useState('')
   const [isValidPassword, setIsValidPassword] = React.useState(true)
+
+  React.useEffect(() => {
+      const query_params = Constants.getSearchParamsDict()
+      if (Object.keys(query_params).includes("from")){
+        if (query_params["from"] == "reset-password"){
+          setHelperText('Your password has been reset. You can now login with the new password.')
+          setShowHelperText(true)
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
   const handleUsernameChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setUsername(value)
@@ -42,6 +54,44 @@ const Login: React.FunctionComponent = () => {
     auth.loginAction({ email: username, password: password })
   }
 
+  const onResetPassword = () => {
+    if (!username) {
+      setHelperText('Invalid email')
+      setShowHelperText(true)
+      return
+    }
+    const url = Constants.API_BASE_URL + Constants.API_USER_RESET_PASSWORD_ENDPOINT
+    const data = {
+      "email": username
+    }
+
+    fetch(url, {
+      method: 'POST',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+    .then((res) => {
+      if (!res.ok){
+        return res.text()
+      } else {
+        return res.json()
+      }
+    })
+    .then((data) => {
+        if (Object.keys(data).includes("message")){
+          setHelperText(data["message"])
+        } else {
+          setHelperText(data)
+        }
+        setShowHelperText(true)
+    })
+    .catch((err) => {
+      setHelperText(err.message)
+      setShowHelperText(true)
+      console.log(err.message)
+    })
+  }
+
   React.useEffect(() => {
     if (typeof auth.loginMessage != 'undefined') {
       if (auth.loginMessage.length > 0) {
@@ -57,7 +107,10 @@ const Login: React.FunctionComponent = () => {
     </LoginMainFooterBandItem>
   )
 
-  const forgotCredentials = <LoginMainFooterBandItem>Forgot username or password? Please contact your BASIL admin.</LoginMainFooterBandItem>
+  const forgotCredentials = (
+    <LoginMainFooterBandItem>
+      Forgot username or password? <Button variant='link' onClick={() => onResetPassword()}>Reset your password</Button>
+    </LoginMainFooterBandItem>)
 
   const listItem = (
     <React.Fragment>
@@ -77,8 +130,8 @@ const Login: React.FunctionComponent = () => {
     <LoginForm
       showHelperText={showHelperText}
       helperText={helperText} //'Invalid login credentials.'
-      helperTextIcon={<ExclamationCircleIcon />}
-      usernameLabel='Username'
+      helperTextIcon={<Icon size={'md'}><ExclamationCircleIcon /></Icon>}
+      usernameLabel='Email'
       usernameValue={username}
       onChangeUsername={handleUsernameChange}
       isValidUsername={isValidUsername}

--- a/app/src/app/Login/Login.tsx
+++ b/app/src/app/Login/Login.tsx
@@ -18,15 +18,15 @@ const Login: React.FunctionComponent = () => {
   const [isValidPassword, setIsValidPassword] = React.useState(true)
 
   React.useEffect(() => {
-      const query_params = Constants.getSearchParamsDict()
-      if (Object.keys(query_params).includes("from")){
-        if (query_params["from"] == "reset-password"){
-          setHelperText('Your password has been reset. You can now login with the new password.')
-          setShowHelperText(true)
-        }
+    const query_params = Constants.getSearchParamsDict()
+    if (Object.keys(query_params).includes('from')) {
+      if (query_params['from'] == 'reset-password') {
+        setHelperText('Your password has been reset. You can now login with the new password.')
+        setShowHelperText(true)
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleUsernameChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setUsername(value)
@@ -62,7 +62,7 @@ const Login: React.FunctionComponent = () => {
     }
     const url = Constants.API_BASE_URL + Constants.API_USER_RESET_PASSWORD_ENDPOINT
     const data = {
-      "email": username
+      email: username
     }
 
     fetch(url, {
@@ -70,26 +70,26 @@ const Login: React.FunctionComponent = () => {
       headers: Constants.JSON_HEADER,
       body: JSON.stringify(data)
     })
-    .then((res) => {
-      if (!res.ok){
-        return res.text()
-      } else {
-        return res.json()
-      }
-    })
-    .then((data) => {
-        if (Object.keys(data).includes("message")){
-          setHelperText(data["message"])
+      .then((res) => {
+        if (!res.ok) {
+          return res.text()
+        } else {
+          return res.json()
+        }
+      })
+      .then((data) => {
+        if (Object.keys(data).includes('message')) {
+          setHelperText(data['message'])
         } else {
           setHelperText(data)
         }
         setShowHelperText(true)
-    })
-    .catch((err) => {
-      setHelperText(err.message)
-      setShowHelperText(true)
-      console.log(err.message)
-    })
+      })
+      .catch((err) => {
+        setHelperText(err.message)
+        setShowHelperText(true)
+        console.log(err.message)
+      })
   }
 
   React.useEffect(() => {
@@ -109,8 +109,12 @@ const Login: React.FunctionComponent = () => {
 
   const forgotCredentials = (
     <LoginMainFooterBandItem>
-      Forgot username or password? <Button variant='link' onClick={() => onResetPassword()}>Reset your password</Button>
-    </LoginMainFooterBandItem>)
+      Forgot username or password?{' '}
+      <Button variant='link' onClick={() => onResetPassword()}>
+        Reset your password
+      </Button>
+    </LoginMainFooterBandItem>
+  )
 
   const listItem = (
     <React.Fragment>
@@ -130,7 +134,11 @@ const Login: React.FunctionComponent = () => {
     <LoginForm
       showHelperText={showHelperText}
       helperText={helperText} //'Invalid login credentials.'
-      helperTextIcon={<Icon size={'md'}><ExclamationCircleIcon /></Icon>}
+      helperTextIcon={
+        <Icon size={'md'}>
+          <ExclamationCircleIcon />
+        </Icon>
+      }
       usernameLabel='Email'
       usernameValue={username}
       onChangeUsername={handleUsernameChange}

--- a/app/src/app/Signin/Signin.tsx
+++ b/app/src/app/Signin/Signin.tsx
@@ -27,9 +27,11 @@ import { useAuth } from '../User/AuthProvider'
 const Signin: React.FunctionComponent = () => {
   const auth = useAuth()
   const [alertMessage, setAlertMessage] = React.useState('')
+  const [username, setUsername] = React.useState('')
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [passwordConfirm, setPasswordConfirm] = React.useState('')
+  const [validateUsernameValue, setValidateUsernameValue] = React.useState<Constants.validate>('default')
   const [validateEmailValue, setValidateEmailValue] = React.useState<Constants.validate>('default')
   const [validatePasswordValue, setValidatePassworValue] = React.useState<Constants.validate>('default')
   const [validatePasswordConfirmValue, setValidatePasswordConfirmValue] = React.useState<Constants.validate>('default')
@@ -39,8 +41,12 @@ const Signin: React.FunctionComponent = () => {
     setPassword(password)
   }
 
-  const handlePasswordConfirmChange = (_event, password: string) => {
-    setPasswordConfirm(password)
+  const handlePasswordConfirmChange = (_event, confirm_password: string) => {
+    setPasswordConfirm(confirm_password)
+  }
+
+  const handleUsernameChange = (_event, username: string) => {
+    setUsername(username)
   }
 
   const handleEmailChange = (_event, email: string) => {
@@ -58,17 +64,35 @@ const Signin: React.FunctionComponent = () => {
   }
 
   React.useEffect(() => {
-    if (email.trim() === '') {
+    if (username == '') {
+      setValidateUsernameValue('error')
+    } else if (username.includes(' ')){
+      setValidateUsernameValue('error')
+    } else if (username.length < 4){
+      setValidateUsernameValue('error')
+    } else {
+      setValidateUsernameValue('success')
+    }
+  }, [username])
+
+  React.useEffect(() => {
+    if (email == '') {
+      setValidateEmailValue('error')
+    } else if (email.includes(' ')){
       setValidateEmailValue('error')
     } else if (!isEmail(email)) {
-      setValidateEmailValue('error2')
+      setValidateEmailValue('error')
     } else {
       setValidateEmailValue('success')
     }
   }, [email])
 
   React.useEffect(() => {
-    if (password.trim() === '') {
+    if (password == '') {
+      setValidatePassworValue('error')
+    } else if (password.includes(' ')){
+      setValidatePassworValue('error')
+    } else if (password.length < 4){
       setValidatePassworValue('error')
     } else {
       setValidatePassworValue('success')
@@ -78,7 +102,11 @@ const Signin: React.FunctionComponent = () => {
   }, [password])
 
   React.useEffect(() => {
-    if (passwordConfirm.trim() === '') {
+    if (passwordConfirm == '') {
+      setValidatePasswordConfirmValue('error')
+    } else if (passwordConfirm.includes(' ')){
+      setValidatePasswordConfirmValue('error')
+    } else if (passwordConfirm.length < 4){
       setValidatePasswordConfirmValue('error')
     } else {
       setValidatePasswordConfirmValue('success')
@@ -88,6 +116,7 @@ const Signin: React.FunctionComponent = () => {
   }, [passwordConfirm])
 
   const resetForm = () => {
+    setUsername('')
     setEmail('')
     setPassword('')
     setPasswordConfirm('')
@@ -100,24 +129,31 @@ const Signin: React.FunctionComponent = () => {
     }
 
     if (validateEmailValue != 'success') {
-      setAlertMessage('Email is mandatory.')
+      setAlertMessage('Email is not valid')
+      return
+    } else if (validateUsernameValue != 'success') {
+      setAlertMessage('Username is not valid, It must be at least 4 chars, space char is not allowed')
       return
     } else if (validatePasswordValue != 'success') {
-      setAlertMessage('Passord is mandatory.')
+      setAlertMessage('Passord is not valid')
       return
     } else if (validatePasswordConfirmValue != 'success') {
-      setAlertMessage('Password Confirm is mandatory.')
+      setAlertMessage('Confirm password is not valid')
       return
     } else if (validatePasswordValues != 'success') {
-      setAlertMessage('Password fields are not the same.')
+      setAlertMessage('Password fields are not the same')
       return
     } else {
       setAlertMessage('')
     }
 
-    const data = { email: email, password: password }
+    const data = { 
+      email: email, 
+      password: password, 
+      username: username
+    }
 
-    fetch(Constants.API_BASE_URL + '/user/signin', {
+    fetch(Constants.API_BASE_URL + Constants.API_USER_SIGNIN_ENDPOINT, {
       method: 'POST',
       headers: Constants.JSON_HEADER,
       body: JSON.stringify(data)
@@ -126,7 +162,7 @@ const Signin: React.FunctionComponent = () => {
         if (response.status !== 200) {
           setAlertMessage(response.statusText)
         } else {
-          setAlertMessage('User configured!')
+          setAlertMessage('User created!')
           window.location.href = '/login'
         }
       })
@@ -157,12 +193,11 @@ const Signin: React.FunctionComponent = () => {
                 <Flex>
                   <FlexItem align={{ default: 'alignLeft' }}>
                     <Form isHorizontal>
-                      <FormGroup label='Email' isRequired fieldId='signin-form-email-01'>
+                      <FormGroup label='Email' isRequired fieldId='signin-form-email'>
                         <TextInput
                           isRequired
                           type='email'
-                          id='signin-form-email-01'
-                          name='signin-form-email-01'
+                          id='signin-form-email'
                           value={email}
                           onChange={handleEmailChange}
                         />
@@ -170,18 +205,35 @@ const Signin: React.FunctionComponent = () => {
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validateEmailValue === 'error' ? 'This field is mandatory' : ''}
+                                {validateEmailValue === 'error' ? 'This field is mandatory, the current value is not valid. It must be an email address and space char is not allowed.' : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>
                         )}
                       </FormGroup>
-                      <FormGroup label='Password' isRequired fieldId='signin-form-password-02'>
+                      <FormGroup label='Username' isRequired fieldId='signin-form-username'>
+                        <TextInput
+                          isRequired
+                          type='text'
+                          id='signin-form-username'
+                          value={username}
+                          onChange={handleUsernameChange}
+                        />
+                        {validateUsernameValue !== 'success' && (
+                          <FormHelperText>
+                            <HelperText>
+                              <HelperTextItem variant='warning'>
+                                {validateUsernameValue === 'error' ? 'This field is mandatory, the current value is not valid. It must be at least 4 chars and space char is not allowed.' : ''}
+                              </HelperTextItem>
+                            </HelperText>
+                          </FormHelperText>
+                        )}
+                      </FormGroup>
+                      <FormGroup label='Password' isRequired fieldId='signin-form-password'>
                         <TextInput
                           isRequired
                           type='password'
-                          id='signin-form-password-02'
-                          name='signin-form-password-02'
+                          id='signin-form-password'
                           value={password}
                           onChange={handlePasswordChange}
                         />
@@ -189,18 +241,17 @@ const Signin: React.FunctionComponent = () => {
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validatePasswordValue === 'error' ? 'This field is mandatory' : ''}
+                                {validatePasswordValue === 'error' ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.' : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>
                         )}
                       </FormGroup>
-                      <FormGroup label='Password Confirm' isRequired fieldId='signin-form-password-confirm-03'>
+                      <FormGroup label='Password Confirm' isRequired fieldId='signin-form-password-confirm'>
                         <TextInput
                           isRequired
                           type='password'
                           id='signin-form-password-confirm-03'
-                          name='signin-form-password-confirm-03'
                           value={passwordConfirm}
                           onChange={handlePasswordConfirmChange}
                         />
@@ -208,7 +259,7 @@ const Signin: React.FunctionComponent = () => {
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validatePasswordConfirmValue === 'error' ? 'This field is mandatory' : ''}
+                                {validatePasswordConfirmValue === 'error' ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.' : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>

--- a/app/src/app/Signin/Signin.tsx
+++ b/app/src/app/Signin/Signin.tsx
@@ -66,9 +66,9 @@ const Signin: React.FunctionComponent = () => {
   React.useEffect(() => {
     if (username == '') {
       setValidateUsernameValue('error')
-    } else if (username.includes(' ')){
+    } else if (username.includes(' ')) {
       setValidateUsernameValue('error')
-    } else if (username.length < 4){
+    } else if (username.length < 4) {
       setValidateUsernameValue('error')
     } else {
       setValidateUsernameValue('success')
@@ -78,7 +78,7 @@ const Signin: React.FunctionComponent = () => {
   React.useEffect(() => {
     if (email == '') {
       setValidateEmailValue('error')
-    } else if (email.includes(' ')){
+    } else if (email.includes(' ')) {
       setValidateEmailValue('error')
     } else if (!isEmail(email)) {
       setValidateEmailValue('error')
@@ -90,9 +90,9 @@ const Signin: React.FunctionComponent = () => {
   React.useEffect(() => {
     if (password == '') {
       setValidatePassworValue('error')
-    } else if (password.includes(' ')){
+    } else if (password.includes(' ')) {
       setValidatePassworValue('error')
-    } else if (password.length < 4){
+    } else if (password.length < 4) {
       setValidatePassworValue('error')
     } else {
       setValidatePassworValue('success')
@@ -104,9 +104,9 @@ const Signin: React.FunctionComponent = () => {
   React.useEffect(() => {
     if (passwordConfirm == '') {
       setValidatePasswordConfirmValue('error')
-    } else if (passwordConfirm.includes(' ')){
+    } else if (passwordConfirm.includes(' ')) {
       setValidatePasswordConfirmValue('error')
-    } else if (passwordConfirm.length < 4){
+    } else if (passwordConfirm.length < 4) {
       setValidatePasswordConfirmValue('error')
     } else {
       setValidatePasswordConfirmValue('success')
@@ -147,9 +147,9 @@ const Signin: React.FunctionComponent = () => {
       setAlertMessage('')
     }
 
-    const data = { 
-      email: email, 
-      password: password, 
+    const data = {
+      email: email,
+      password: password,
       username: username
     }
 
@@ -194,54 +194,42 @@ const Signin: React.FunctionComponent = () => {
                   <FlexItem align={{ default: 'alignLeft' }}>
                     <Form isHorizontal>
                       <FormGroup label='Email' isRequired fieldId='signin-form-email'>
-                        <TextInput
-                          isRequired
-                          type='email'
-                          id='signin-form-email'
-                          value={email}
-                          onChange={handleEmailChange}
-                        />
+                        <TextInput isRequired type='email' id='signin-form-email' value={email} onChange={handleEmailChange} />
                         {validateEmailValue !== 'success' && (
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validateEmailValue === 'error' ? 'This field is mandatory, the current value is not valid. It must be an email address and space char is not allowed.' : ''}
+                                {validateEmailValue === 'error'
+                                  ? 'This field is mandatory, the current value is not valid. It must be an email address and space char is not allowed.'
+                                  : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>
                         )}
                       </FormGroup>
                       <FormGroup label='Username' isRequired fieldId='signin-form-username'>
-                        <TextInput
-                          isRequired
-                          type='text'
-                          id='signin-form-username'
-                          value={username}
-                          onChange={handleUsernameChange}
-                        />
+                        <TextInput isRequired type='text' id='signin-form-username' value={username} onChange={handleUsernameChange} />
                         {validateUsernameValue !== 'success' && (
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validateUsernameValue === 'error' ? 'This field is mandatory, the current value is not valid. It must be at least 4 chars and space char is not allowed.' : ''}
+                                {validateUsernameValue === 'error'
+                                  ? 'This field is mandatory, the current value is not valid. It must be at least 4 chars and space char is not allowed.'
+                                  : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>
                         )}
                       </FormGroup>
                       <FormGroup label='Password' isRequired fieldId='signin-form-password'>
-                        <TextInput
-                          isRequired
-                          type='password'
-                          id='signin-form-password'
-                          value={password}
-                          onChange={handlePasswordChange}
-                        />
+                        <TextInput isRequired type='password' id='signin-form-password' value={password} onChange={handlePasswordChange} />
                         {validatePasswordValue !== 'success' && (
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validatePasswordValue === 'error' ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.' : ''}
+                                {validatePasswordValue === 'error'
+                                  ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.'
+                                  : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>
@@ -259,7 +247,9 @@ const Signin: React.FunctionComponent = () => {
                           <FormHelperText>
                             <HelperText>
                               <HelperTextItem variant='warning'>
-                                {validatePasswordConfirmValue === 'error' ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.' : ''}
+                                {validatePasswordConfirmValue === 'error'
+                                  ? 'This field is mandatory, the current value is not valid. It should be at least 4 chars and space char is not allowed.'
+                                  : ''}
                               </HelperTextItem>
                             </HelperText>
                           </FormHelperText>

--- a/app/src/app/User/AuthProvider.tsx
+++ b/app/src/app/User/AuthProvider.tsx
@@ -130,7 +130,9 @@ const AuthProvider = ({ children }) => {
   }
 
   return (
-    <AuthContext.Provider value={{ token, userEmail, userName, userId, userRole, loginAction, loginMessage, logOut, isLogged, isAdmin, isGuest }}>
+    <AuthContext.Provider
+      value={{ token, userEmail, userName, userId, userRole, loginAction, loginMessage, logOut, isLogged, isAdmin, isGuest }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/app/src/app/User/AuthProvider.tsx
+++ b/app/src/app/User/AuthProvider.tsx
@@ -19,16 +19,18 @@ const AuthProvider = ({ children }) => {
 
   const [userId, setUserId] = useState(localStorage.getItem('uId') || '')
   const [userRole, setUserRole] = useState(localStorage.getItem('uRole') || '')
+  const [userName, setUserName] = useState(localStorage.getItem('uName') || '')
   const [userEmail, setUserEmail] = useState(localStorage.getItem('uEmail') || '')
   const [token, setToken] = useState(localStorage.getItem('uToken') || '')
   const [loginMessage, setLoginMessage] = useState('')
 
   React.useEffect(() => {
     localStorage.setItem('uId', userId == null ? '' : userId)
+    localStorage.setItem('uName', userName == null ? '' : userName)
     localStorage.setItem('uEmail', userEmail == null ? '' : userEmail)
     localStorage.setItem('uRole', userRole == null ? '' : userRole)
     localStorage.setItem('uToken', token == null ? '' : token)
-  }, [userId, userRole, userEmail, token])
+  }, [userId, userRole, userEmail, userName, token])
 
   const loginAction = (data) => {
     setLoginMessage('')
@@ -47,6 +49,7 @@ const AuthProvider = ({ children }) => {
             //if (response_data.hasOwnProperty('token')) {
             if (Object.prototype.hasOwnProperty.call(response_data, 'token')) {
               setUserEmail(response_data['email'])
+              setUserName(response_data['username'])
               setUserId(response_data['id'])
               setUserRole(response_data['role'])
               setToken(response_data['token'])
@@ -72,10 +75,12 @@ const AuthProvider = ({ children }) => {
   const logOut = () => {
     console.log('logout')
     setUserEmail('')
+    setUserName('')
     setUserId('')
     setUserRole('')
     setToken('')
     localStorage.removeItem('uEmail')
+    localStorage.removeItem('uName')
     localStorage.removeItem('uId')
     localStorage.removeItem('uToken')
     localStorage.removeItem('uRole')
@@ -125,7 +130,7 @@ const AuthProvider = ({ children }) => {
   }
 
   return (
-    <AuthContext.Provider value={{ token, userEmail, userId, userRole, loginAction, loginMessage, logOut, isLogged, isAdmin, isGuest }}>
+    <AuthContext.Provider value={{ token, userEmail, userName, userId, userRole, loginAction, loginMessage, logOut, isLogged, isAdmin, isGuest }}>
       {children}
     </AuthContext.Provider>
   )

--- a/app/src/app/User/Modal/UserProfileModal.tsx
+++ b/app/src/app/User/Modal/UserProfileModal.tsx
@@ -1,0 +1,348 @@
+import React from 'react'
+import { useAuth } from '@app/User/AuthProvider'
+import { 
+  Button, 
+  FormGroup, 
+  FormHelperText, 
+  HelperText,
+  HelperTextItem,
+  Hint,
+  HintBody,
+  Modal, 
+  ModalVariant, 
+  Tab, 
+  TabContent, 
+  TabContentBody, 
+  TabTitleText, 
+  Tabs,
+  TextInput,
+} from '@patternfly/react-core'
+import * as Constants from '@app/Constants/constants'
+
+export interface UserProfileModalProps {
+  modalShowState
+  setModalShowState
+}
+
+export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = ({
+  modalShowState = false,
+  setModalShowState
+}: UserProfileModalProps) => {
+  const auth = useAuth()
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+  const [modalFormSubmitState, setModalFormSubmitState] = React.useState('waiting')
+
+  const [profileUsernameValue, setProfileUsernameValue] = React.useState(auth.userName || '')
+  const [validatedProfileUsernameValue, setValidatedProfileUsernameValue] = React.useState<Constants.validate>('error')
+  
+  const [currentPasswordValue, setCurrentPasswordValue] = React.useState('')
+  const [validatedCurrentPasswordValue, setValidatedCurrentPasswordValue] = React.useState<Constants.validate>('error')
+  const [newPasswordValue, setNewPasswordValue] = React.useState('')
+  const [validatedNewPasswordValue, setValidatedNewPasswordValue] = React.useState<Constants.validate>('error')
+  const [confirmPasswordValue, setConfirmPasswordValue] = React.useState('')
+  const [validatedConfirmPasswordValue, setValidatedConfirmPasswordValue] = React.useState<Constants.validate>('error')
+  
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0)
+  const [messageValue, setMessageValue] = React.useState<string>('')
+
+  // Toggle currently active tab
+  const handleTabClick = (event: React.MouseEvent | React.KeyboardEvent | MouseEvent, tabIndex: string | number) => {
+    setActiveTabKey(tabIndex)
+  }
+
+  const handleModalToggle = () => {
+    const new_state = !modalShowState
+    setModalShowState(new_state)
+    setIsModalOpen(new_state)
+  }
+
+  React.useEffect(() => {
+    setIsModalOpen(modalShowState)
+    if (modalShowState){
+      setMessageValue('')
+    }
+  }, [modalShowState])
+
+  const comparePasswords = () => {
+    if (newPasswordValue != confirmPasswordValue) {
+      setValidatedConfirmPasswordValue('error')
+    } else {
+      setValidatedConfirmPasswordValue('success')
+    }
+  }
+
+  React.useEffect(() => {
+    if (profileUsernameValue == '') {
+      setValidatedProfileUsernameValue('error')
+    } else if (profileUsernameValue.includes(' ')){
+      setValidatedProfileUsernameValue('error')
+    } else if (profileUsernameValue.length < 4){
+      setValidatedProfileUsernameValue('error')
+    } else {
+      setValidatedProfileUsernameValue('success')
+    }
+  }, [profileUsernameValue])
+
+  React.useEffect(() => {
+    if (currentPasswordValue == '') {
+      setValidatedCurrentPasswordValue('error')
+    } else if (currentPasswordValue.includes(' ')){
+      setValidatedCurrentPasswordValue('error')
+    } else if (currentPasswordValue.length < 4){
+      setValidatedCurrentPasswordValue('error')
+    } else {
+      setValidatedCurrentPasswordValue('success')
+      comparePasswords()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPasswordValue])
+
+  React.useEffect(() => {
+    if (newPasswordValue == '') {
+      setValidatedNewPasswordValue('error')
+    } else if (newPasswordValue.includes(' ')){
+      setValidatedNewPasswordValue('error')
+    } else if (newPasswordValue.length < 4){
+      setValidatedNewPasswordValue('error')
+    } else {
+      setValidatedNewPasswordValue('success')
+      comparePasswords()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newPasswordValue])
+
+  React.useEffect(() => {
+    if (confirmPasswordValue == '') {
+      setValidatedConfirmPasswordValue('error')
+    } else if (confirmPasswordValue.includes(' ')){
+      setValidatedConfirmPasswordValue('error')
+    } else if (confirmPasswordValue.length < 4){
+      setValidatedConfirmPasswordValue('error')
+    } else {
+      setValidatedConfirmPasswordValue('success')
+      comparePasswords()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmPasswordValue])
+  
+  const handleProfileUsernameValueChange = (_ev, value) => {
+    setProfileUsernameValue(value)
+  }
+
+  const handleCurrentPasswordValueChange = (_ev, value) => {
+    setCurrentPasswordValue(value)
+  }
+  
+  const handleNewPasswordValueChange = (_ev, value) => {
+    setNewPasswordValue(value)
+  }
+
+  const handleConfirmPasswordValueChange = (_ev, value) => {
+    setConfirmPasswordValue(value)
+  }
+
+  const profileInfoRef = React.createRef<HTMLElement>()
+  const editPasswordRef = React.createRef<HTMLElement>()
+
+  const EditUserProfile = (_username, _password) => {
+    setMessageValue('')
+    if (!auth.isLogged()) {
+      return
+    }
+
+    const url = Constants.API_BASE_URL + Constants.API_USER_ENDPOINT
+    let data = {
+      "user-id": auth.userId,
+      "token": auth.token
+    }
+
+    if (_username != null && _username != undefined){
+      if (_username == auth.userName){
+        setMessageValue("The username you selected is your current one. No changes needed.")
+        return
+      }
+      if (validatedProfileUsernameValue != 'success'){
+        return
+      }
+      data["username"] = _username
+    }
+    
+    if (_password != null && _password != undefined){
+      if (validatedCurrentPasswordValue != 'success'){
+        return
+      }
+      if (validatedNewPasswordValue != 'success'){
+        return
+      }
+      if (validatedConfirmPasswordValue != 'success'){
+        return
+      }
+      if (currentPasswordValue == newPasswordValue){
+        setMessageValue("The password you selected is your current one. No changes needed.")
+        return
+      }
+      data["password"] = _password
+    }
+      
+    let status: number = 0
+    let status_text: string = ''
+    
+    fetch(url, {
+      method: 'PUT',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        status = response.status
+        status_text = response.statusText
+        if (status !== 200) {
+          return response.text()
+        } else {
+          return response.json()
+        }
+      })
+      .then((data) => {
+        if (status != 200) {
+          setMessageValue(Constants.getResponseErrorMessage(status, status_text, data))
+        } else {
+          setMessageValue(data["message"])
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
+  }
+
+  return (
+    <React.Fragment>
+      <Modal
+        width={Constants.MODAL_WIDTH}
+        bodyAriaLabel='UserProfileModal'
+        aria-label='user profile modal'
+        tabIndex={0}
+        variant={ModalVariant.default}
+        title='User Profile'
+        description={'Edit your profile information'}
+        isOpen={isModalOpen}
+        onClose={handleModalToggle}
+        actions={[]}
+      >
+        {messageValue ? (
+        <Hint>
+          <HintBody>
+            {messageValue}
+          </HintBody> 
+        </Hint>) : ('')}
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} aria-label='Add a New/Existing Test Case' role='region'>
+          <Tab
+            eventKey={0}
+            id='tab-user-profile-info'
+            title={<TabTitleText>Profile</TabTitleText>}
+            tabContentId='tabUserProfile'
+            tabContentRef={profileInfoRef}
+          />
+          <Tab
+            eventKey={1}
+            id='tab-user-edit-password'
+            title={<TabTitleText>Edit Password</TabTitleText>}
+            tabContentId='tabUserEditPassword'
+            tabContentRef={editPasswordRef}
+          />
+        </Tabs>
+        <div>
+          <TabContent eventKey={0} id='tabUserProfile' ref={profileInfoRef} hidden={0 !== activeTabKey}>
+            <TabContentBody hasPadding>
+              <FormGroup label='Username' isRequired fieldId={`input-user-profile-username`}>
+                <TextInput
+                  isRequired
+                  id={`input-user-profile-username`}
+                  value={profileUsernameValue}
+                  onChange={(_ev, value) => handleProfileUsernameValueChange(_ev, value)}
+                />
+                {validatedProfileUsernameValue !== 'success' && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant='error'>{validatedProfileUsernameValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
+              </FormGroup>
+              <br></br>
+              <FormGroup label='Eamil' fieldId={`input-user-profile-email`}>
+                <TextInput
+                  id={`input-user-profile-email`}
+                  readOnlyVariant={'default'}
+                  value={auth.userEmail}
+                />
+              </FormGroup>
+              <br></br>
+              <br></br>
+              <Button id="btn-user-profile-save" onClick={() => (EditUserProfile(profileUsernameValue, null))}>
+                Save
+              </Button>
+            </TabContentBody>
+          </TabContent>
+          <TabContent eventKey={1} id='tabUserEditPassword' ref={editPasswordRef} hidden={1 !== activeTabKey}>
+            <TabContentBody hasPadding>
+              <FormGroup label='Current Password' isRequired fieldId={`input-user-edit-password-current`}>
+                <TextInput
+                  isRequired
+                  type={'password'}
+                  id={`input-user-edit-password-current`}
+                  value={currentPasswordValue}
+                  onChange={(_ev, value) => handleCurrentPasswordValueChange(_ev, value)}
+                />
+                {validatedCurrentPasswordValue !== 'success' && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant='error'>{validatedCurrentPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
+              </FormGroup>
+              <br></br>
+              <FormGroup label='New Password' isRequired fieldId={`input-user-edit-password-new`}>
+                <TextInput
+                  isRequired
+                  type={'password'}
+                  id={`input-user-edit-password-new`}
+                  value={newPasswordValue}
+                  onChange={(_ev, value) => handleNewPasswordValueChange(_ev, value)}
+                />
+                {validatedNewPasswordValue !== 'success' && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant='error'>{validatedNewPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
+              </FormGroup>
+              <br></br>
+              <FormGroup label='Confirm New Password' isRequired fieldId={`input-user-edit-password-confirm`}>
+                <TextInput
+                  isRequired
+                  type={'password'}
+                  id={`input-user-edit-password-confirm`}
+                  value={confirmPasswordValue}
+                  onChange={(_ev, value) => handleConfirmPasswordValueChange(_ev, value)}
+                />
+                {validatedConfirmPasswordValue !== 'success' && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant='error'>{validatedConfirmPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
+              </FormGroup>
+              <br></br>
+              <br></br>
+              <Button id="btn-user-edit-password-save" onClick={() => (EditUserProfile(null, newPasswordValue))}>
+                Save
+              </Button>
+            </TabContentBody>
+          </TabContent>
+        </div>
+      </Modal>
+    </React.Fragment>
+  )
+}

--- a/app/src/app/User/Modal/UserProfileModal.tsx
+++ b/app/src/app/User/Modal/UserProfileModal.tsx
@@ -1,21 +1,21 @@
 import React from 'react'
 import { useAuth } from '@app/User/AuthProvider'
-import { 
-  Button, 
-  FormGroup, 
-  FormHelperText, 
+import {
+  Button,
+  FormGroup,
+  FormHelperText,
   HelperText,
   HelperTextItem,
   Hint,
   HintBody,
-  Modal, 
-  ModalVariant, 
-  Tab, 
-  TabContent, 
-  TabContentBody, 
-  TabTitleText, 
+  Modal,
+  ModalVariant,
+  Tab,
+  TabContent,
+  TabContentBody,
+  TabTitleText,
   Tabs,
-  TextInput,
+  TextInput
 } from '@patternfly/react-core'
 import * as Constants from '@app/Constants/constants'
 
@@ -34,14 +34,14 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
 
   const [profileUsernameValue, setProfileUsernameValue] = React.useState(auth.userName || '')
   const [validatedProfileUsernameValue, setValidatedProfileUsernameValue] = React.useState<Constants.validate>('error')
-  
+
   const [currentPasswordValue, setCurrentPasswordValue] = React.useState('')
   const [validatedCurrentPasswordValue, setValidatedCurrentPasswordValue] = React.useState<Constants.validate>('error')
   const [newPasswordValue, setNewPasswordValue] = React.useState('')
   const [validatedNewPasswordValue, setValidatedNewPasswordValue] = React.useState<Constants.validate>('error')
   const [confirmPasswordValue, setConfirmPasswordValue] = React.useState('')
   const [validatedConfirmPasswordValue, setValidatedConfirmPasswordValue] = React.useState<Constants.validate>('error')
-  
+
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0)
   const [messageValue, setMessageValue] = React.useState<string>('')
 
@@ -58,7 +58,7 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
 
   React.useEffect(() => {
     setIsModalOpen(modalShowState)
-    if (modalShowState){
+    if (modalShowState) {
       setMessageValue('')
     }
   }, [modalShowState])
@@ -74,9 +74,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
   React.useEffect(() => {
     if (profileUsernameValue == '') {
       setValidatedProfileUsernameValue('error')
-    } else if (profileUsernameValue.includes(' ')){
+    } else if (profileUsernameValue.includes(' ')) {
       setValidatedProfileUsernameValue('error')
-    } else if (profileUsernameValue.length < 4){
+    } else if (profileUsernameValue.length < 4) {
       setValidatedProfileUsernameValue('error')
     } else {
       setValidatedProfileUsernameValue('success')
@@ -86,9 +86,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
   React.useEffect(() => {
     if (currentPasswordValue == '') {
       setValidatedCurrentPasswordValue('error')
-    } else if (currentPasswordValue.includes(' ')){
+    } else if (currentPasswordValue.includes(' ')) {
       setValidatedCurrentPasswordValue('error')
-    } else if (currentPasswordValue.length < 4){
+    } else if (currentPasswordValue.length < 4) {
       setValidatedCurrentPasswordValue('error')
     } else {
       setValidatedCurrentPasswordValue('success')
@@ -100,9 +100,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
   React.useEffect(() => {
     if (newPasswordValue == '') {
       setValidatedNewPasswordValue('error')
-    } else if (newPasswordValue.includes(' ')){
+    } else if (newPasswordValue.includes(' ')) {
       setValidatedNewPasswordValue('error')
-    } else if (newPasswordValue.length < 4){
+    } else if (newPasswordValue.length < 4) {
       setValidatedNewPasswordValue('error')
     } else {
       setValidatedNewPasswordValue('success')
@@ -114,9 +114,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
   React.useEffect(() => {
     if (confirmPasswordValue == '') {
       setValidatedConfirmPasswordValue('error')
-    } else if (confirmPasswordValue.includes(' ')){
+    } else if (confirmPasswordValue.includes(' ')) {
       setValidatedConfirmPasswordValue('error')
-    } else if (confirmPasswordValue.length < 4){
+    } else if (confirmPasswordValue.length < 4) {
       setValidatedConfirmPasswordValue('error')
     } else {
       setValidatedConfirmPasswordValue('success')
@@ -124,7 +124,7 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [confirmPasswordValue])
-  
+
   const handleProfileUsernameValueChange = (_ev, value) => {
     setProfileUsernameValue(value)
   }
@@ -132,7 +132,7 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
   const handleCurrentPasswordValueChange = (_ev, value) => {
     setCurrentPasswordValue(value)
   }
-  
+
   const handleNewPasswordValueChange = (_ev, value) => {
     setNewPasswordValue(value)
   }
@@ -152,41 +152,41 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
 
     const url = Constants.API_BASE_URL + Constants.API_USER_ENDPOINT
     let data = {
-      "user-id": auth.userId,
-      "token": auth.token
+      'user-id': auth.userId,
+      token: auth.token
     }
 
-    if (_username != null && _username != undefined){
-      if (_username == auth.userName){
-        setMessageValue("The username you selected is your current one. No changes needed.")
+    if (_username != null && _username != undefined) {
+      if (_username == auth.userName) {
+        setMessageValue('The username you selected is your current one. No changes needed.')
         return
       }
-      if (validatedProfileUsernameValue != 'success'){
+      if (validatedProfileUsernameValue != 'success') {
         return
       }
-      data["username"] = _username
+      data['username'] = _username
     }
-    
-    if (_password != null && _password != undefined){
-      if (validatedCurrentPasswordValue != 'success'){
+
+    if (_password != null && _password != undefined) {
+      if (validatedCurrentPasswordValue != 'success') {
         return
       }
-      if (validatedNewPasswordValue != 'success'){
+      if (validatedNewPasswordValue != 'success') {
         return
       }
-      if (validatedConfirmPasswordValue != 'success'){
+      if (validatedConfirmPasswordValue != 'success') {
         return
       }
-      if (currentPasswordValue == newPasswordValue){
-        setMessageValue("The password you selected is your current one. No changes needed.")
+      if (currentPasswordValue == newPasswordValue) {
+        setMessageValue('The password you selected is your current one. No changes needed.')
         return
       }
-      data["password"] = _password
+      data['password'] = _password
     }
-      
+
     let status: number = 0
     let status_text: string = ''
-    
+
     fetch(url, {
       method: 'PUT',
       headers: Constants.JSON_HEADER,
@@ -205,7 +205,7 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
         if (status != 200) {
           setMessageValue(Constants.getResponseErrorMessage(status, status_text, data))
         } else {
-          setMessageValue(data["message"])
+          setMessageValue(data['message'])
         }
       })
       .catch((err) => {
@@ -228,11 +228,12 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
         actions={[]}
       >
         {messageValue ? (
-        <Hint>
-          <HintBody>
-            {messageValue}
-          </HintBody> 
-        </Hint>) : ('')}
+          <Hint>
+            <HintBody>{messageValue}</HintBody>
+          </Hint>
+        ) : (
+          ''
+        )}
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick} aria-label='Add a New/Existing Test Case' role='region'>
           <Tab
             eventKey={0}
@@ -262,22 +263,20 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
                 {validatedProfileUsernameValue !== 'success' && (
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem variant='error'>{validatedProfileUsernameValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                      <HelperTextItem variant='error'>
+                        {validatedProfileUsernameValue === 'error' ? 'This field is mandatory' : ''}
+                      </HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 )}
               </FormGroup>
               <br></br>
               <FormGroup label='Eamil' fieldId={`input-user-profile-email`}>
-                <TextInput
-                  id={`input-user-profile-email`}
-                  readOnlyVariant={'default'}
-                  value={auth.userEmail}
-                />
+                <TextInput id={`input-user-profile-email`} readOnlyVariant={'default'} value={auth.userEmail} />
               </FormGroup>
               <br></br>
               <br></br>
-              <Button id="btn-user-profile-save" onClick={() => (EditUserProfile(profileUsernameValue, null))}>
+              <Button id='btn-user-profile-save' onClick={() => EditUserProfile(profileUsernameValue, null)}>
                 Save
               </Button>
             </TabContentBody>
@@ -295,7 +294,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
                 {validatedCurrentPasswordValue !== 'success' && (
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem variant='error'>{validatedCurrentPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                      <HelperTextItem variant='error'>
+                        {validatedCurrentPasswordValue === 'error' ? 'This field is mandatory' : ''}
+                      </HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 )}
@@ -312,7 +313,9 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
                 {validatedNewPasswordValue !== 'success' && (
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem variant='error'>{validatedNewPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                      <HelperTextItem variant='error'>
+                        {validatedNewPasswordValue === 'error' ? 'This field is mandatory' : ''}
+                      </HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 )}
@@ -329,14 +332,16 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
                 {validatedConfirmPasswordValue !== 'success' && (
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem variant='error'>{validatedConfirmPasswordValue === 'error' ? 'This field is mandatory' : ''}</HelperTextItem>
+                      <HelperTextItem variant='error'>
+                        {validatedConfirmPasswordValue === 'error' ? 'This field is mandatory' : ''}
+                      </HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 )}
               </FormGroup>
               <br></br>
               <br></br>
-              <Button id="btn-user-edit-password-save" onClick={() => (EditUserProfile(null, newPasswordValue))}>
+              <Button id='btn-user-edit-password-save' onClick={() => EditUserProfile(null, newPasswordValue)}>
                 Save
               </Button>
             </TabContentBody>

--- a/app/src/app/routes.tsx
+++ b/app/src/app/routes.tsx
@@ -3,6 +3,7 @@ import { Route, RouteComponentProps, Switch, useLocation } from 'react-router-do
 import { Dashboard } from '@app/Dashboard/Dashboard'
 import { Admin } from '@app/Admin/Admin'
 import { AdminTestRunPluginPresets } from '@app/Admin/AdminTestRunPluginPresets'
+import { AdminSettings } from '@app/Admin/AdminSettings'
 import { Login } from '@app/Login/Login'
 import { Mapping } from '@app/Mapping/Mapping'
 import { NotFound } from '@app/NotFound/NotFound'
@@ -71,6 +72,13 @@ const routes: AppRouteConfig[] = [
     label: 'Test Run Plugins Presets',
     path: '/plugins-presets',
     title: 'BASIL | The Fusa Spice | Admin | Test Run Plugins Presets'
+  },
+  {
+    component: AdminSettings,
+    exact: true,
+    label: 'Settings',
+    path: '/settings',
+    title: 'BASIL | The Fusa Spice | Admin | Settings'
   },
   {
     component: SSHKey,

--- a/db/models/init_db.py
+++ b/db/models/init_db.py
@@ -51,14 +51,14 @@ def initialization(db_name='basil.db'):
             UserModel.role == 'ADMIN'
         ).count()
         if not admin_count:
-            admin = UserModel("admin", os.getenv('BASIL_ADMIN_PASSWORD'), 'ADMIN')
+            admin = UserModel("admin", "admin", os.getenv('BASIL_ADMIN_PASSWORD'), 'ADMIN')
             dbi.session.add(admin)
         del os.environ['BASIL_ADMIN_PASSWORD']
 
     if db_name == 'test.db':
-        guest = UserModel("dummy_guest", "dummy_guest", "GUEST")
+        guest = UserModel("dummy_guest", "dummy_guest", "dummy_guest", "GUEST")
         dbi.session.add(guest)
-        test_user = UserModel("dummy_user", "dummy_user", "USER")
+        test_user = UserModel("dummy_guest", "dummy_user", "dummy_user", "USER")
         dbi.session.add(test_user)
 
     dbi.session.commit()

--- a/db/models/migration/sqlite_1_6_3.sql
+++ b/db/models/migration/sqlite_1_6_3.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ADD COLUMN username VARCHAR(100) DEFAULT '';
+ALTER TABLE users ADD COLUMN reset_pwd VARCHAR(100) DEFAULT '';
+ALTER TABLE users ADD COLUMN reset_token VARCHAR(100) DEFAULT '';
+UPDATE users SET username = substr(email, 1, instr(email, '@') - 1);

--- a/db/models/user.py
+++ b/db/models/user.py
@@ -14,8 +14,11 @@ class UserModel(Base):
     extend_existing = True
     id: Mapped[int] = mapped_column(BigInteger().with_variant(Integer, "sqlite"),
                                     primary_key=True)
+    username: Mapped[Optional[str]] = mapped_column(String(100))
     email: Mapped[str] = mapped_column(String(255))
     pwd: Mapped[str] = mapped_column(String)
+    reset_pwd: Mapped[Optional[str]] = mapped_column(String(100))
+    reset_token: Mapped[Optional[str]] = mapped_column(String(100))
     enabled: Mapped[int] = mapped_column(Integer)
     role: Mapped[str] = mapped_column(String(100))
     token: Mapped[str] = mapped_column(String(255))
@@ -23,9 +26,12 @@ class UserModel(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, onupdate=datetime.now)
 
-    def __init__(self, email, pwd, role):
+    def __init__(self, username, email, pwd, role):
+        self.username = username
         self.email = email
         self.pwd = base64.b64encode(pwd.encode('utf-8')).decode('utf-8')
+        self.reset_pwd = ''
+        self.reset_token = ''
         self.role = role
         self.enabled = 1
         self.token = str(uuid4())
@@ -34,12 +40,14 @@ class UserModel(Base):
 
     def __repr__(self) -> str:
         return f"User(id={self.id!r}, " \
+               f"username={self.username!r}, " \
                f"email={self.email!r}, " \
                f"enabled={self.enabled!r}, " \
                f"role={self.role!r}"
 
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
+                 "username": self.username,
                  "email": self.email,
                  "enabled": self.enabled,
                  "role": self.role,


### PR DESCRIPTION
This PR solves the #60 

Added admin settings page to configure the smtp server and the APP endpoint.
Added frontend and backend support to:
- Reset password via email
- Edit user profile information such as username and password

The password reset works as following:
in the users table I added a field for a temporary password and a field for a token.
The temporary password is shared via email to the user and a link with the token is provided as part of the email to activate the new password. If the email is not wanted by the user nothing happen as the temporary password is not active. So user can continue to login with his original password.

If the reset is wanted, user can press the link in the email and temporary password will be activated.
If admin configure the APP endpoint correctly user will be redirect to the login page of the frontend.

@nopeppermint May I ask your review on this PR?
