### PR TITLE
Container app optimizations

### DIFF
--- a/Containerfile-app
+++ b/Containerfile-app
@@ -1,21 +1,36 @@
-FROM node:16
+# Builder Container
+# -----------------
+FROM node:18 AS builder
 USER root
-RUN mkdir BASIL-APP
-COPY ./app /BASIL-APP
-WORKDIR /BASIL-APP
+
+RUN mkdir BASIL-APP-BUILD
+COPY . /BASIL-APP-BUILD
+WORKDIR /BASIL-APP-BUILD/app
+RUN npm install
 
 # Set the public ip
-ARG API_ENDPOINT=http://localhost:5000 \
-    APP_PORT=9000
+ARG API_ENDPOINT=http://localhost:5000
 
 RUN sed -i "s#http://localhost:5000#${API_ENDPOINT}#g" src/app/Constants/constants.tsx && \
-    sed -i "s#--port 9000#--port ${APP_PORT}#g" package.json && \
-    npm install -d --verbose && \
     npm run build
 
-# In case of reverse proxy
-# RUN sed -i "s/src=\"\//src=\"/g" dist/index.html
-# RUN sed -i "s/href=\"\//href=\"/g" dist/index.html
+# Deployment Container
+# --------------------
+FROM docker.io/nginx:latest
+
+ARG APP_PORT=9000
+
+RUN mkdir BASIL-APP
+WORKDIR /BASIL-APP
+
+COPY --from=builder /BASIL-APP-BUILD/app/dist /BASIL-APP/dist
+
+# Set group permissions to the app dirs
+RUN chmod -R 0755 /BASIL-APP
+
+COPY nginx.conf /etc/nginx/nginx.conf
+RUN sed -i "s#0.0.0.0:80#0.0.0.0:${APP_PORT}#g" /etc/nginx/nginx.conf
 
 EXPOSE ${APP_PORT}
-CMD ["npm", "run", "start"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]
+

--- a/app/webpack.prod.js
+++ b/app/webpack.prod.js
@@ -12,10 +12,32 @@ module.exports = merge(common('production'), {
   devtool: 'source-map',
   optimization: {
     splitChunks: {
-      chunks: 'all'
+      chunks: 'all',
+      minSize: 30000,
+      maxSize: 244000,
+      automaticNameDelimiter: '-',
     },
     minimizer: [
-      new TerserJSPlugin({}),
+      new TerserJSPlugin({
+        terserOptions: {
+          compress: {
+            drop_console: true,
+            drop_debugger: true,
+            pure_getters: true,
+            passes: 3,
+            reduce_vars: true,
+            collapse_vars: true,
+            negate_iife: false,
+          },
+          mangle: {
+            reserved: ['$', 'exports', 'require'],
+          },
+          output: {
+            comments: false,
+          },
+        },
+        parallel: true,
+      }),
       new CssMinimizerPlugin({
         minimizerOptions: {
           preset: ['default', { mergeLonghand: false }]
@@ -39,3 +61,4 @@ module.exports = merge(common('production'), {
     ]
   }
 })
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,24 @@
+user www-data;
+worker_processes auto;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    server {
+        listen 0.0.0.0:80;
+        server_name _;
+
+        root /BASIL-APP/dist;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
Containerfile-app split build and deploy in 2 stages, to minimize final container size that is now 165 MB.
Serve the web application via nginx. 
Configure webpack production chunk sizes and other options.

Refers to #132 