### PR TITLE
Fix how populate Api related env variable 

### DIFF
--- a/api/testrun_testing_farm.py
+++ b/api/testrun_testing_farm.py
@@ -76,10 +76,10 @@ class TestRunnerTestingFarmPlugin(TestRunnerBasePlugin):
         self.payload["environments"][0]["variables"]["uid"] = self.runner.db_test_run.uid
         self.payload["environments"][0]["variables"]["basil_test_case_id"] = self.runner.mapping.test_case.id
         self.payload["environments"][0]["variables"]["basil_test_case_title"] = self.runner.mapping.test_case.title
-        self.payload["environments"][0]["variables"]["basil_api_api"] = self.runner.mapping.api.api
-        self.payload["environments"][0]["variables"]["basil_api_library"] = self.runner.mapping.api.library
+        self.payload["environments"][0]["variables"]["basil_api_api"] = self.runner.db_test_run.api.api
+        self.payload["environments"][0]["variables"]["basil_api_library"] = self.runner.db_test_run.api.library
         self.payload["environments"][0]["variables"]["basil_api_library_version"] = \
-            self.runner.mapping.api.library_version
+            self.runner.db_test_run.api.library_version
         self.payload["environments"][0]["variables"]["basil_test_case_mapping_table"] = \
             self.runner.db_test_run.mapping_to
         self.payload["environments"][0]["variables"]["basil_test_case_mapping_id"] = self.runner.db_test_run.mapping_id

--- a/api/testrun_tmt.py
+++ b/api/testrun_tmt.py
@@ -30,9 +30,9 @@ class TestRunnerTmtPlugin(TestRunnerBasePlugin):
         self.config["env"]["uid"] = self.runner.db_test_run.uid
         self.config["env"]["basil_test_case_id"] = self.runner.mapping.test_case.id
         self.config["env"]["basil_test_case_title"] = self.runner.mapping.test_case.title
-        self.config["env"]["basil_api_api"] = self.runner.mapping.api.api
-        self.config["env"]["basil_api_library"] = self.runner.mapping.api.library
-        self.config["env"]["basil_api_library_version"] = self.runner.mapping.api.library_version
+        self.config["env"]["basil_api_api"] = self.runner.db_test_run.api.api
+        self.config["env"]["basil_api_library"] = self.runner.db_test_run.api.library
+        self.config["env"]["basil_api_library_version"] = self.runner.db_test_run.api.library_version
         self.config["env"]["basil_test_case_mapping_table"] = self.runner.db_test_run.mapping_to
         self.config["env"]["basil_test_case_mapping_id"] = self.runner.db_test_run.mapping_id
         self.config["env"]["basil_test_relative_path"] = self.runner.mapping.test_case.relative_path


### PR DESCRIPTION
Use db_test_run instead of mapping in tmt and testing farm plugin. 
Not all the mapping models have direct access to the api information (indirect mapping eg API -> Test Specification -> Test Case) .