### PR TITLE
CI - pytest coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,15 @@ jobs:
       - name: API unit testing 
         run: |
           source venv/bin/activate
-          pytest -v ./api/test
+          pytest -v ./api/test --cov=api --cov-branch --cov-report=term --cov-report=html
+      - name: Create tarball of coverage report
+        run: |
+          tar -czf api-htmlcov.tar.gz htmlcov
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-coverage-html-report
+          path: api-htmlcov.tar.gz
       - name: Download basil-api artifacts
         uses: actions/download-artifact@v4
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ SQLAlchemy==2.0.19
 gunicorn==21.2.0
 pyaml-env==1.2.1
 pytest==8.0.1
+pytest-cov==4.1.0
 python-gitlab==3.15.0
 requests==2.28.2
 spdx-tools==0.8.3


### PR DESCRIPTION
Add code coverage support for the API and collect the html folder into a tarball that will be exposed as an artifacts for further analysis.