### PR TITLE
Fix spdx jsonld generation preventing duplicate ids

### DIFF
--- a/api/spdx_manager.py
+++ b/api/spdx_manager.py
@@ -568,7 +568,8 @@ class SPDXManager:
 
         if element not in self.sbom:
             # check the element id doesn't exists yet
-            ids = [item.spdx_id for item in self.sbom if item.to_dict().get("spdxId", None)]
+            # use the internal spdx_id for all items (covers both spdxId and @id in serialized form)
+            ids = {item.spdx_id for item in self.sbom}
             if spdx_id not in ids:
                 self.sbom.append(element)
 

--- a/api/test/test_spdx_api_validation.py
+++ b/api/test/test_spdx_api_validation.py
@@ -269,6 +269,16 @@ def comprehensive_spdx_test_data(client_db, ut_user_db, utilities):
         95,
         user,
     )
+    # Duplicate mapping against the same section (different SW requirement)
+    # to validate snippet/CreationInfo deduplication
+    api_sr_mapping_auth_dup = ApiSwRequirementModel(
+        ut_api,
+        sw_req_3,
+        "## Section 1: Authentication",
+        _UT_API_SPEC_CONTENT.find("## Section 1: Authentication"),
+        80,
+        user,
+    )
     api_sr_mapping_2 = ApiSwRequirementModel(
         ut_api,
         sw_req_2,
@@ -353,6 +363,7 @@ def comprehensive_spdx_test_data(client_db, ut_user_db, utilities):
     # Add all mappings to session
     mappings = [
         api_sr_mapping_1,
+        api_sr_mapping_auth_dup,
         api_sr_mapping_2,
         sr_sr_mapping,
         api_ts_mapping_1,

--- a/app/src/app/Mapping/MappingPageSection.tsx
+++ b/app/src/app/Mapping/MappingPageSection.tsx
@@ -415,9 +415,9 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
                   <LeavesProgressBar progressValue={totalCoverage} progressId='api-mapping-coverage' />
                 </FlexItem>
               </Flex>
-              {api?.permissions?.indexOf('w') >= 0 ? (
+              {auth.isLogged() ? (
                 <Flex align={{ default: 'alignRight' }}>
-                  {auth.isLogged() ? (
+                  {api?.permissions?.indexOf('r') >= 0 ? (
                     <FlexItem>
                       <Button
                         id='btn-export-sw-component-to-spdx'
@@ -431,56 +431,62 @@ const MappingPageSection: React.FunctionComponent<MappingPageSectionProps> = ({
                   ) : (
                     ''
                   )}
-                  <FlexItem>
-                    <Button
-                      variant='secondary'
-                      id='btn-mapping-new-sw-requirement'
-                      isDisabled={api?.raw_specification == null}
-                      onClick={() => setSrModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
-                    >
-                      Map Software Req.
-                    </Button>
-                  </FlexItem>
-                  <FlexItem>
-                    <Button
-                      variant='secondary'
-                      id='btn-mapping-new-test-specification'
-                      isDisabled={api?.raw_specification == null}
-                      onClick={() => setTsModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
-                    >
-                      Map Test Specification
-                    </Button>
-                  </FlexItem>
-                  <FlexItem>
-                    <Button
-                      variant='secondary'
-                      id='btn-mapping-new-test-case'
-                      isDisabled={api?.raw_specification == null}
-                      onClick={() => setTcModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
-                    >
-                      Map Test Case
-                    </Button>
-                  </FlexItem>
-                  <FlexItem>
-                    <Button
-                      variant='secondary'
-                      id='btn-mapping-new-justification'
-                      isDisabled={api?.raw_specification == null}
-                      onClick={() => setJModalInfo(true, 'add', api, '', 0, [], -1)}
-                    >
-                      Map Justification
-                    </Button>
-                  </FlexItem>
-                  <FlexItem>
-                    <Button
-                      variant='secondary'
-                      id='btn-mapping-new-document'
-                      isDisabled={api?.raw_specification == null}
-                      onClick={() => setDocModalInfo(true, 'add', api, '', 0, [], -1)}
-                    >
-                      Map Document
-                    </Button>
-                  </FlexItem>
+                  {api?.permissions?.indexOf('w') >= 0 ? (
+                    <React.Fragment>
+                      <FlexItem>
+                        <Button
+                          variant='secondary'
+                          id='btn-mapping-new-sw-requirement'
+                          isDisabled={api?.raw_specification == null}
+                          onClick={() => setSrModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
+                        >
+                          Map Software Req.
+                        </Button>
+                      </FlexItem>
+                      <FlexItem>
+                        <Button
+                          variant='secondary'
+                          id='btn-mapping-new-test-specification'
+                          isDisabled={api?.raw_specification == null}
+                          onClick={() => setTsModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
+                        >
+                          Map Test Specification
+                        </Button>
+                      </FlexItem>
+                      <FlexItem>
+                        <Button
+                          variant='secondary'
+                          id='btn-mapping-new-test-case'
+                          isDisabled={api?.raw_specification == null}
+                          onClick={() => setTcModalInfo(true, false, 'add', api, '', 0, Constants._A, [], -1, '')}
+                        >
+                          Map Test Case
+                        </Button>
+                      </FlexItem>
+                      <FlexItem>
+                        <Button
+                          variant='secondary'
+                          id='btn-mapping-new-justification'
+                          isDisabled={api?.raw_specification == null}
+                          onClick={() => setJModalInfo(true, 'add', api, '', 0, [], -1)}
+                        >
+                          Map Justification
+                        </Button>
+                      </FlexItem>
+                      <FlexItem>
+                        <Button
+                          variant='secondary'
+                          id='btn-mapping-new-document'
+                          isDisabled={api?.raw_specification == null}
+                          onClick={() => setDocModalInfo(true, 'add', api, '', 0, [], -1)}
+                        >
+                          Map Document
+                        </Button>
+                      </FlexItem>
+                    </React.Fragment>
+                  ) : (
+                    ''
+                  )}
                 </Flex>
               ) : (
                 ''


### PR DESCRIPTION
Fix spdx jsonld generation preventing duplicate ids. 
Improved the test to simulate a case where a possible duplicate should appear in the exported file. 
Export to SPDX button should be visible in case of read permission