### PR TITLE
Fix typo: 'Eamil' → 'Email' in UserProfileModal

### DIFF
--- a/app/src/app/User/Modal/UserProfileModal.tsx
+++ b/app/src/app/User/Modal/UserProfileModal.tsx
@@ -275,7 +275,7 @@ export const UserProfileModal: React.FunctionComponent<UserProfileModalProps> = 
                 <TextInput id={`input-user-profile-role`} isDisabled={true} readOnlyVariant={'default'} value={auth.userRole} />
               </FormGroup>
               <br></br>
-              <FormGroup label='Eamil' fieldId={`input-user-profile-email`}>
+              <FormGroup label='Email' fieldId={`input-user-profile-email`}>
                 <TextInput id={`input-user-profile-email`} readOnlyVariant={'default'} value={auth.userEmail} />
               </FormGroup>
               <br></br>


### PR DESCRIPTION
## Summary
Corrected typo in the Email field label of the user profile modal.

**Changes:**
- Fixed label from 'Eamil' to 'Email' in `UserProfileModal.tsx`

## Location
File: `app/src/app/User/Modal/UserProfileModal.tsx:278`

This PR replaces the closed PR #213 with a clean commit based on the latest main branch.