### PR TITLE
Rename API listing section and column titles

### DIFF
--- a/app/src/app/Dashboard/APIListingPageSection.tsx
+++ b/app/src/app/Dashboard/APIListingPageSection.tsx
@@ -148,7 +148,7 @@ const APIListingPageSection: React.FunctionComponent<APIListingPageSectionProps>
           <Flex>
             <Flex>
               <FlexItem>
-                <Title headingLevel='h1'>API Listing for {currentLibrary}</Title>
+                <Title headingLevel='h1'>Listing Software Components for {currentLibrary}</Title>
               </FlexItem>
               <FlexItem>
                 <Label color='green' isCompact>

--- a/app/src/app/Dashboard/APIListingTable.tsx
+++ b/app/src/app/Dashboard/APIListingTable.tsx
@@ -77,7 +77,7 @@ const APIListingTable: React.FunctionComponent<APIListingTableProps> = ({
 
   const columnNames = {
     id: 'ID',
-    api: 'API',
+    api: 'Name',
     library_version: 'Version',
     created_by: 'Owner',
     category: 'Category',


### PR DESCRIPTION
Fixes #229 

Changes:
- Renamed section title from "API Listing for experimentation" to "Listing Software Components for experimentation"
- Renamed table column header from "API" to "Name"

This aligns the terminology with the Software Components context.
<img width="990" height="89" alt="image" src="https://github.com/user-attachments/assets/7556a1a6-47f4-4ea0-a742-15b2d524868b" />
<img width="398" height="288" alt="image" src="https://github.com/user-attachments/assets/51077d8a-e634-45dc-b452-84a0094dc99e" />
