### PR TITLE
Add justification delete endpoint and UI delete button

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5690,7 +5690,7 @@ class Justification(Resource):
         dbi = get_db()
         query = dbi.session.query(JustificationModel)
         query = filter_query(query, request_data, JustificationModel, False)
-        jus = [ju.as_dict() for ju in query.all()]
+        jus = [ju.as_dict(db_session=dbi.session) for ju in query.all()]
 
         if "mode" in request_data.keys():
             if request_data["mode"] == "minimal":
@@ -5698,6 +5698,40 @@ class Justification(Resource):
                 jus = [{key: val for key, val in sub.items() if key in minimal_keys} for sub in jus]
 
         api_response.set_data(jus)
+        return api_response.return_ok()
+
+    @api_response_decorator
+    def delete(self, api_response: ApiResponse = None):
+        request_data = request.get_json(force=True)
+        mandatory_fields = ["id", "user-id", "token"]
+
+        wrong_fields = get_wrong_mandatory_fields(mandatory_fields, request_data)
+        if len(wrong_fields) > 0:
+            api_response.set_missing_fields(wrong_fields)
+            return api_response.return_bad_request_missing_fields()
+
+        dbi = get_db()
+
+        # User
+        user = get_active_user_from_request(request_data, dbi.session)
+        if not isinstance(user, UserModel):
+            return api_response.return_unauthorized()
+
+        # Permissions
+        if user.role not in USER_ROLES_WRITE_PERMISSIONS:
+            return api_response.return_unauthorized()
+
+        # Justification
+        justification = dbi.session.query(JustificationModel).filter(JustificationModel.id == request_data["id"]).one()
+        if not justification:
+            return api_response.return_not_found()
+
+        if justification.is_used(dbi.session):
+            api_response.set_message("Justification is used and cannot be deleted")
+            return api_response.return_bad_request()
+
+        dbi.session.delete(justification)
+        dbi.session.commit()
         return api_response.return_ok()
 
 

--- a/api/test/test_justification.py
+++ b/api/test/test_justification.py
@@ -1,0 +1,238 @@
+import pytest
+from http import HTTPStatus
+
+from db.models.user import UserModel
+from db.models.justification import JustificationModel
+from db.models.api_justification import ApiJustificationModel
+from db.models.api import ApiModel
+
+from conftest import (
+    UT_USER_EMAIL,
+    UT_USER_PASSWORD,
+    AuthActions,
+)
+
+_JUSTIFICATIONS_URL = '/justifications'
+
+_UT_GUEST_NAME = 'ut_guest_name'
+_UT_GUEST_EMAIL = 'ut_guest_email'
+_UT_GUEST_PASSWORD = 'ut_guest_password'
+
+
+@pytest.fixture(scope="module")
+def guest_user_db(client_db):
+    from db import db_orm
+    dbi = db_orm.DbInterface('test')
+    guest = UserModel(_UT_GUEST_NAME, _UT_GUEST_EMAIL, _UT_GUEST_PASSWORD, 'GUEST')
+    dbi.session.add(guest)
+    dbi.session.commit()
+    yield guest
+
+
+@pytest.fixture(scope="module")
+def guest_authentication(client, guest_user_db):
+    auth = AuthActions(client)
+    return auth.login(email=_UT_GUEST_EMAIL, password=_UT_GUEST_PASSWORD)
+
+
+@pytest.fixture()
+def unused_justification_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+    j = JustificationModel(
+        f'Unused justification #{utilities.generate_random_hex_string8()}',
+        user,
+    )
+    client_db.session.add(j)
+    client_db.session.commit()
+    yield j
+
+
+@pytest.fixture()
+def used_justification_db(client_db, ut_user_db, utilities):
+    """Create a justification that is mapped to an API (i.e. in use)."""
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+
+    j = JustificationModel(
+        f'Used justification #{utilities.generate_random_hex_string8()}',
+        user,
+    )
+    api = ApiModel(
+        f'ut_api_{utilities.generate_random_hex_string8()}',
+        'ut_lib', 'v1', 'stub.md', 'ut_cat',
+        utilities.generate_random_hex_string8(),
+        'stub.impl', 0, 42, 'ut_tags', user,
+    )
+    client_db.session.add(j)
+    client_db.session.add(api)
+    client_db.session.flush()
+
+    mapping = ApiJustificationModel(api, j, 'section', 0, 0, user)
+    client_db.session.add(mapping)
+    client_db.session.commit()
+    yield j
+
+
+# ------------------------------------------------------------------
+# GET
+# ------------------------------------------------------------------
+
+def test_login(user_authentication):
+    assert user_authentication.status_code == HTTPStatus.OK
+
+
+def test_get_justifications_ok(client, unused_justification_db):
+    response = client.get(_JUSTIFICATIONS_URL)
+    assert response.status_code == HTTPStatus.OK
+    assert isinstance(response.json, list)
+    assert len(response.json) > 0
+
+
+def test_get_justifications_fields(client, unused_justification_db):
+    response = client.get(_JUSTIFICATIONS_URL)
+    assert response.status_code == HTTPStatus.OK
+    justification = next(
+        (j for j in response.json if j['id'] == unused_justification_db.id),
+        None,
+    )
+    assert justification is not None
+    assert 'id' in justification
+    assert 'description' in justification
+    assert 'status' in justification
+    assert 'created_by' in justification
+    assert 'version' in justification
+    assert 'used' in justification
+
+
+def test_get_justifications_used_flag_false(client, unused_justification_db):
+    response = client.get(
+        _JUSTIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': unused_justification_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is False
+
+
+def test_get_justifications_used_flag_true(client, used_justification_db):
+    response = client.get(
+        _JUSTIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': used_justification_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is True
+
+
+def test_get_justifications_minimal_mode(client, unused_justification_db):
+    response = client.get(
+        _JUSTIFICATIONS_URL,
+        query_string={'mode': 'minimal'},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) > 0
+    for j in response.json:
+        assert set(j.keys()) == {'id', 'description'}
+
+
+# ------------------------------------------------------------------
+# DELETE
+# ------------------------------------------------------------------
+
+def test_delete_missing_auth_fields(client, unused_justification_db):
+    response = client.delete(
+        _JUSTIFICATIONS_URL,
+        json={'id': unused_justification_db.id},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_invalid_token(client, user_authentication, unused_justification_db):
+    response = client.delete(
+        _JUSTIFICATIONS_URL,
+        json={
+            'id': unused_justification_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': 'invalid-token',
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_delete_guest_forbidden(client, guest_authentication, unused_justification_db):
+    response = client.delete(
+        _JUSTIFICATIONS_URL,
+        json={
+            'id': unused_justification_db.id,
+            'user-id': guest_authentication.json['id'],
+            'token': guest_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize('missing_field', ['id', 'user-id', 'token'])
+def test_delete_missing_mandatory_field(client, user_authentication, unused_justification_db, missing_field):
+    data = {
+        'id': unused_justification_db.id,
+        'user-id': user_authentication.json['id'],
+        'token': user_authentication.json['token'],
+    }
+    data.pop(missing_field)
+    response = client.delete(_JUSTIFICATIONS_URL, json=data)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_used_justification(client, user_authentication, used_justification_db):
+    response = client.delete(
+        _JUSTIFICATIONS_URL,
+        json={
+            'id': used_justification_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_nonexistent_justification(client, user_authentication):
+    from sqlalchemy.exc import NoResultFound
+    non_existent_id = 99999
+    with pytest.raises(NoResultFound):
+        client.delete(
+            _JUSTIFICATIONS_URL,
+            json={
+                'id': non_existent_id,
+                'user-id': user_authentication.json['id'],
+                'token': user_authentication.json['token'],
+            },
+        )
+
+
+def test_delete_ok(client, client_db, user_authentication, unused_justification_db):
+    justification_id = unused_justification_db.id
+
+    response = client.get(
+        _JUSTIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': justification_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+
+    response = client.delete(
+        _JUSTIFICATIONS_URL,
+        json={
+            'id': justification_id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    response = client.get(
+        _JUSTIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': justification_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 0

--- a/api/test/test_justification.py
+++ b/api/test/test_justification.py
@@ -8,7 +8,6 @@ from db.models.api import ApiModel
 
 from conftest import (
     UT_USER_EMAIL,
-    UT_USER_PASSWORD,
     AuthActions,
 )
 

--- a/app/src/app/Mapping/Search/JustificationSearch.tsx
+++ b/app/src/app/Mapping/Search/JustificationSearch.tsx
@@ -12,9 +12,11 @@ import {
   HelperTextItem,
   Hint,
   HintBody,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@patternfly/react-core'
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow, SearchInput } from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
 import { useAuth } from '@app/User/AuthProvider'
 
 export interface JustificationSearchProps {
@@ -54,11 +56,48 @@ export const JustificationSearch: React.FunctionComponent<JustificationSearchPro
   const [initializedValue, setInitializedValue] = React.useState(false)
   const [coverageValue, setCoverageValue] = React.useState(formData?.coverage || '100')
   const [validatedCoverageValue, setValidatedCoverageValue] = React.useState<Constants.validate>('error')
+  const [confirmDeleteId, setConfirmDeleteId] = React.useState<number | null>(null)
 
   const resetForm = () => {
     setSelectedDataListItemId('')
     setCoverageValue('100')
     setSearchValue('')
+  }
+
+  const handleDeleteJustification = (justificationId: number) => {
+    if (confirmDeleteId !== justificationId) {
+      setConfirmDeleteId(justificationId)
+      return
+    }
+    setConfirmDeleteId(null)
+
+    const data = {
+      id: justificationId,
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(Constants.API_BASE_URL + Constants.API_JUSTIFICATIONS_ROOT_ENDPOINT, {
+      method: 'DELETE',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        const status = response.status
+        const status_text = response.statusText
+        if (Constants.isHttpSuccessStatus(status)) {
+          setMessageValue('Justification deleted with success.')
+          loadJustifications(searchValue)
+          return
+        } else {
+          return response.text().then((text) => {
+            setMessageValue(Constants.getResponseErrorMessage(status, status_text, text))
+          })
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
   }
 
   const onChangeSearchValue = (value) => {
@@ -67,10 +106,12 @@ export const JustificationSearch: React.FunctionComponent<JustificationSearchPro
 
   const onSelectDataListItem = (_event: React.MouseEvent | React.KeyboardEvent, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   React.useEffect(() => {
@@ -111,7 +152,41 @@ export const JustificationSearch: React.FunctionComponent<JustificationSearchPro
                 <span id={'clickable-action-item-' + justification.id}>
                   {justification.id} - {justification.description}
                 </span>
-              </DataListCell>
+              </DataListCell>,
+              ...(auth.isLogged() && !auth.isGuest()
+                ? [
+                    <DataListCell key={`delete-${justification.id}`} alignRight isFilled={false}>
+                      {justification.used ? (
+                        <Tooltip content='Cannot delete: justification is in use'>
+                          <div>
+                            <Button
+                              id={`btn-delete-justification-${justification.id}`}
+                              variant='plain'
+                              aria-label='Cannot delete justification'
+                              isDisabled
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </div>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={confirmDeleteId === justification.id ? 'Click again to confirm' : 'Delete justification'}>
+                          <Button
+                            id={`btn-delete-justification-${justification.id}`}
+                            variant={confirmDeleteId === justification.id ? 'danger' : 'plain'}
+                            aria-label='Delete justification'
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDeleteJustification(justification.id)
+                            }}
+                          >
+                            <TrashIcon /> {confirmDeleteId === justification.id ? ' Confirm?' : ''}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </DataListCell>
+                  ]
+                : [])
             ]}
           />
         </DataListItemRow>

--- a/db/models/justification.py
+++ b/db/models/justification.py
@@ -48,6 +48,14 @@ class JustificationModel(Base):
                      JustificationHistoryModel.version.desc()).limit(1).all()[0]
         return f'{last_item.version}'
 
+    def is_used(self, db_session) -> bool:
+        if db_session is None:
+            return True
+        from db.models.api_justification import ApiJustificationModel
+        api_justifications = db_session.query(ApiJustificationModel).filter(
+            ApiJustificationModel.justification_id == self.id).all()
+        return len(api_justifications) > 0
+
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
                  "description": self.description,
@@ -57,6 +65,7 @@ class JustificationModel(Base):
 
         if db_session:
             _dict['version'] = self.current_version(db_session)
+            _dict['used'] = self.is_used(db_session)
 
         if full_data:
             _dict["created_at"] = self.created_at.strftime(Base.dt_format_str)


### PR DESCRIPTION
- Add DELETE method to the Justification API resource with auth/permission checks and in-use validation
- Add is_used() method to JustificationModel to check if a justification is referenced by any API justification mapping
- Include 'used' field in justification serialization
- Add trash icon button with two-click confirmation in JustificationSearch
- Disable deletion for justifications that are currently in use
- Add unit test for justification endpoint

Refers to #276 