### PR TITLE
Add software requirement delete endpoint and UI delete button

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5861,7 +5861,7 @@ class SwRequirement(Resource):
 
         query = dbi.session.query(SwRequirementModel)
         query = filter_query(query, request_data, SwRequirementModel, False)
-        srs = [sr.as_dict() for sr in query.all()]
+        srs = [sr.as_dict(db_session=dbi.session) for sr in query.all()]
 
         if "mode" in request_data.keys():
             if request_data["mode"] == "minimal":
@@ -5869,6 +5869,42 @@ class SwRequirement(Resource):
                 srs = [{key: val for key, val in sub.items() if key in minimal_keys} for sub in srs]
 
         api_response.set_data(srs)
+        return api_response.return_ok()
+
+    @api_response_decorator
+    def delete(self, api_response: ApiResponse = None):
+        request_data = request.get_json(force=True)
+        mandatory_fields = ["id", "user-id", "token"]
+
+        wrong_fields = get_wrong_mandatory_fields(mandatory_fields, request_data)
+        if len(wrong_fields) > 0:
+            api_response.set_missing_fields(wrong_fields)
+            return api_response.return_bad_request_missing_fields()
+
+        dbi = get_db()
+
+        # User
+        user = get_active_user_from_request(request_data, dbi.session)
+        if not isinstance(user, UserModel):
+            return api_response.return_unauthorized()
+
+        # Permissions
+        if user.role not in USER_ROLES_WRITE_PERMISSIONS:
+            return api_response.return_unauthorized()
+
+        # Software Requirement
+        sw_requirement = (
+            dbi.session.query(SwRequirementModel).filter(SwRequirementModel.id == request_data["id"]).one()
+        )
+        if not sw_requirement:
+            return api_response.return_not_found()
+
+        if sw_requirement.is_used(dbi.session):
+            api_response.set_message("Software Requirement is used and cannot be deleted")
+            return api_response.return_bad_request()
+
+        dbi.session.delete(sw_requirement)
+        dbi.session.commit()
         return api_response.return_ok()
 
 

--- a/api/test/test_sw_requirement.py
+++ b/api/test/test_sw_requirement.py
@@ -1,0 +1,240 @@
+import pytest
+from http import HTTPStatus
+
+from db.models.user import UserModel
+from db.models.sw_requirement import SwRequirementModel
+from db.models.api_sw_requirement import ApiSwRequirementModel
+from db.models.api import ApiModel
+
+from conftest import (
+    UT_USER_EMAIL,
+    AuthActions,
+)
+
+_SW_REQUIREMENTS_URL = '/sw-requirements'
+
+_UT_GUEST_NAME = 'ut_guest_name'
+_UT_GUEST_EMAIL = 'ut_guest_email'
+_UT_GUEST_PASSWORD = 'ut_guest_password'
+
+
+@pytest.fixture(scope="module")
+def guest_user_db(client_db):
+    from db import db_orm
+    dbi = db_orm.DbInterface('test')
+    guest = UserModel(_UT_GUEST_NAME, _UT_GUEST_EMAIL, _UT_GUEST_PASSWORD, 'GUEST')
+    dbi.session.add(guest)
+    dbi.session.commit()
+    yield guest
+
+
+@pytest.fixture(scope="module")
+def guest_authentication(client, guest_user_db):
+    auth = AuthActions(client)
+    return auth.login(email=_UT_GUEST_EMAIL, password=_UT_GUEST_PASSWORD)
+
+
+@pytest.fixture()
+def unused_sw_requirement_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+    sr = SwRequirementModel(
+        f'Unused SR #{utilities.generate_random_hex_string8()}',
+        f'Description #{utilities.generate_random_hex_string8()}',
+        user,
+    )
+    client_db.session.add(sr)
+    client_db.session.commit()
+    yield sr
+
+
+@pytest.fixture()
+def used_sw_requirement_db(client_db, ut_user_db, utilities):
+    """Create a sw requirement that is mapped to an API (i.e. in use)."""
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+
+    sr = SwRequirementModel(
+        f'Used SR #{utilities.generate_random_hex_string8()}',
+        f'Description #{utilities.generate_random_hex_string8()}',
+        user,
+    )
+    api = ApiModel(
+        f'ut_api_{utilities.generate_random_hex_string8()}',
+        'ut_lib', 'v1', 'stub.md', 'ut_cat',
+        utilities.generate_random_hex_string8(),
+        'stub.impl', 0, 42, 'ut_tags', user,
+    )
+    client_db.session.add(sr)
+    client_db.session.add(api)
+    client_db.session.flush()
+
+    mapping = ApiSwRequirementModel(api, sr, 'section', 0, 0, user)
+    client_db.session.add(mapping)
+    client_db.session.commit()
+    yield sr
+
+
+# ------------------------------------------------------------------
+# GET
+# ------------------------------------------------------------------
+
+def test_login(user_authentication):
+    assert user_authentication.status_code == HTTPStatus.OK
+
+
+def test_get_sw_requirements_ok(client, unused_sw_requirement_db):
+    response = client.get(_SW_REQUIREMENTS_URL)
+    assert response.status_code == HTTPStatus.OK
+    assert isinstance(response.json, list)
+    assert len(response.json) > 0
+
+
+def test_get_sw_requirements_fields(client, unused_sw_requirement_db):
+    response = client.get(_SW_REQUIREMENTS_URL)
+    assert response.status_code == HTTPStatus.OK
+    sw_requirement = next(
+        (sr for sr in response.json if sr['id'] == unused_sw_requirement_db.id),
+        None,
+    )
+    assert sw_requirement is not None
+    assert 'id' in sw_requirement
+    assert 'title' in sw_requirement
+    assert 'description' in sw_requirement
+    assert 'status' in sw_requirement
+    assert 'created_by' in sw_requirement
+    assert 'version' in sw_requirement
+    assert 'used' in sw_requirement
+
+
+def test_get_sw_requirements_used_flag_false(client, unused_sw_requirement_db):
+    response = client.get(
+        _SW_REQUIREMENTS_URL,
+        query_string={'field1': 'id', 'filter1': unused_sw_requirement_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is False
+
+
+def test_get_sw_requirements_used_flag_true(client, used_sw_requirement_db):
+    response = client.get(
+        _SW_REQUIREMENTS_URL,
+        query_string={'field1': 'id', 'filter1': used_sw_requirement_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is True
+
+
+def test_get_sw_requirements_minimal_mode(client, unused_sw_requirement_db):
+    response = client.get(
+        _SW_REQUIREMENTS_URL,
+        query_string={'mode': 'minimal'},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) > 0
+    for sr in response.json:
+        assert set(sr.keys()) == {'id', 'title'}
+
+
+# ------------------------------------------------------------------
+# DELETE
+# ------------------------------------------------------------------
+
+def test_delete_missing_auth_fields(client, unused_sw_requirement_db):
+    response = client.delete(
+        _SW_REQUIREMENTS_URL,
+        json={'id': unused_sw_requirement_db.id},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_invalid_token(client, user_authentication, unused_sw_requirement_db):
+    response = client.delete(
+        _SW_REQUIREMENTS_URL,
+        json={
+            'id': unused_sw_requirement_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': 'invalid-token',
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_delete_guest_forbidden(client, guest_authentication, unused_sw_requirement_db):
+    response = client.delete(
+        _SW_REQUIREMENTS_URL,
+        json={
+            'id': unused_sw_requirement_db.id,
+            'user-id': guest_authentication.json['id'],
+            'token': guest_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize('missing_field', ['id', 'user-id', 'token'])
+def test_delete_missing_mandatory_field(client, user_authentication, unused_sw_requirement_db, missing_field):
+    data = {
+        'id': unused_sw_requirement_db.id,
+        'user-id': user_authentication.json['id'],
+        'token': user_authentication.json['token'],
+    }
+    data.pop(missing_field)
+    response = client.delete(_SW_REQUIREMENTS_URL, json=data)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_used_sw_requirement(client, user_authentication, used_sw_requirement_db):
+    response = client.delete(
+        _SW_REQUIREMENTS_URL,
+        json={
+            'id': used_sw_requirement_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_nonexistent_sw_requirement(client, user_authentication):
+    from sqlalchemy.exc import NoResultFound
+    non_existent_id = 99999
+    with pytest.raises(NoResultFound):
+        client.delete(
+            _SW_REQUIREMENTS_URL,
+            json={
+                'id': non_existent_id,
+                'user-id': user_authentication.json['id'],
+                'token': user_authentication.json['token'],
+            },
+        )
+
+
+def test_delete_ok(client, client_db, user_authentication, unused_sw_requirement_db):
+    sw_requirement_id = unused_sw_requirement_db.id
+
+    response = client.get(
+        _SW_REQUIREMENTS_URL,
+        query_string={'field1': 'id', 'filter1': sw_requirement_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+
+    response = client.delete(
+        _SW_REQUIREMENTS_URL,
+        json={
+            'id': sw_requirement_id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    response = client.get(
+        _SW_REQUIREMENTS_URL,
+        query_string={'field1': 'id', 'filter1': sw_requirement_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 0

--- a/app/src/app/Mapping/Search/SwRequirementSearch.tsx
+++ b/app/src/app/Mapping/Search/SwRequirementSearch.tsx
@@ -12,9 +12,11 @@ import {
   HelperTextItem,
   Hint,
   HintBody,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@patternfly/react-core'
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow, SearchInput } from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
 import { useAuth } from '@app/User/AuthProvider'
 
 export interface SwRequirementSearchProps {
@@ -62,11 +64,48 @@ export const SwRequirementSearch: React.FunctionComponent<SwRequirementSearchPro
   const [initializedValue, setInitializedValue] = React.useState(false)
   const [coverageValue, setCoverageValue] = React.useState(formData?.coverage || 0)
   const [validatedCoverageValue, setValidatedCoverageValue] = React.useState<Constants.validate>('error')
+  const [confirmDeleteId, setConfirmDeleteId] = React.useState<number | null>(null)
 
   const resetForm = () => {
     setSelectedDataListItemId('')
     setCoverageValue(0)
     setSearchValue('')
+  }
+
+  const handleDeleteSwRequirement = (swRequirementId: number) => {
+    if (confirmDeleteId !== swRequirementId) {
+      setConfirmDeleteId(swRequirementId)
+      return
+    }
+    setConfirmDeleteId(null)
+
+    const data = {
+      id: swRequirementId,
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(Constants.API_BASE_URL + Constants.API_SW_REQUIREMENTS_ROOT_ENDPOINT, {
+      method: 'DELETE',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        const status = response.status
+        const status_text = response.statusText
+        if (Constants.isHttpSuccessStatus(status)) {
+          setMessageValue('Software Requirement deleted with success.')
+          loadSwRequirements(searchValue)
+          return
+        } else {
+          return response.text().then((text) => {
+            setMessageValue(Constants.getResponseErrorMessage(status, status_text, text))
+          })
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
   }
 
   React.useEffect(() => {
@@ -83,10 +122,12 @@ export const SwRequirementSearch: React.FunctionComponent<SwRequirementSearchPro
 
   const onSelectDataListItem = (_event: React.MouseEvent | React.KeyboardEvent, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   React.useEffect(() => {
@@ -119,7 +160,41 @@ export const SwRequirementSearch: React.FunctionComponent<SwRequirementSearchPro
                 <span id={'clickable-action-item-' + sw_requirement.id}>
                   {sw_requirement.id} - {sw_requirement.title}
                 </span>
-              </DataListCell>
+              </DataListCell>,
+              ...(auth.isLogged() && !auth.isGuest()
+                ? [
+                    <DataListCell key={`delete-${sw_requirement.id}`} alignRight isFilled={false}>
+                      {sw_requirement.used ? (
+                        <Tooltip content='Cannot delete: software requirement is in use'>
+                          <div>
+                            <Button
+                              id={`btn-delete-sw-requirement-${sw_requirement.id}`}
+                              variant='plain'
+                              aria-label='Cannot delete software requirement'
+                              isDisabled
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </div>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={confirmDeleteId === sw_requirement.id ? 'Click again to confirm' : 'Delete software requirement'}>
+                          <Button
+                            id={`btn-delete-sw-requirement-${sw_requirement.id}`}
+                            variant={confirmDeleteId === sw_requirement.id ? 'danger' : 'plain'}
+                            aria-label='Delete software requirement'
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDeleteSwRequirement(sw_requirement.id)
+                            }}
+                          >
+                            <TrashIcon /> {confirmDeleteId === sw_requirement.id ? ' Confirm?' : ''}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </DataListCell>
+                  ]
+                : [])
             ]}
           />
         </DataListItemRow>

--- a/db/models/sw_requirement.py
+++ b/db/models/sw_requirement.py
@@ -52,6 +52,19 @@ class SwRequirementModel(Base):
                      SwRequirementHistoryModel.version.desc()).limit(1).all()[0]
         return f'{last_item.version}'
 
+    def is_used(self, db_session) -> bool:
+        if db_session is None:
+            return True
+        from db.models.api_sw_requirement import ApiSwRequirementModel
+        from db.models.sw_requirement_sw_requirement import SwRequirementSwRequirementModel
+        api_sw_requirements = db_session.query(ApiSwRequirementModel).filter(
+            ApiSwRequirementModel.sw_requirement_id == self.id).all()
+        if len(api_sw_requirements) > 0:
+            return True
+        sr_sw_requirements = db_session.query(SwRequirementSwRequirementModel).filter(
+            SwRequirementSwRequirementModel.sw_requirement_id == self.id).all()
+        return len(sr_sw_requirements) > 0
+
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
                  "title": self.title,
@@ -62,6 +75,7 @@ class SwRequirementModel(Base):
 
         if db_session:
             _dict['version'] = self.current_version(db_session)
+            _dict['used'] = self.is_used(db_session)
 
         if full_data:
             _dict["created_at"] = self.created_at.strftime(Base.dt_format_str)


### PR DESCRIPTION
- Add `is_used()` method to `SwRequirementModel` that checks both `ApiSwRequirementModel` and `SwRequirementSwRequirementModel` mappings
- Expose `used` flag in `SwRequirementModel.as_dict` when `db_session` is provided
- Pass `db_session` to `as_dict` in the GET endpoint so the `used` flag is returned
- Add DELETE endpoint for `/sw-requirements` with auth, role, and in-use validation
- Add trash icon with two-click confirmation in `SwRequirementSearch` UI component; disable the button with a tooltip when the requirement is in use
- Add unit tests covering GET field validation, used/unused flags, and DELETE scenarios (missing fields, invalid token, guest forbidden, in-use rejection, nonexistent id, and successful deletion)