### PR TITLE
Add document delete endpoint and UI delete button

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -2769,8 +2769,42 @@ class Document(Resource):
         dbi = get_db()
         query = dbi.session.query(DocumentModel)
         query = filter_query(query, request_data, DocumentModel, False)
-        docs = [doc.as_dict() for doc in query.all()]
+        docs = [doc.as_dict(db_session=dbi.session) for doc in query.all()]
         api_response.set_data(docs)
+        return api_response.return_ok()
+
+    @api_response_decorator
+    def delete(self, api_response: ApiResponse = None):
+        request_data = request.get_json(force=True)
+        mandatory_fields = ["id", "user-id", "token"]
+
+        wrong_fields = get_wrong_mandatory_fields(mandatory_fields, request_data)
+        if len(wrong_fields) > 0:
+            api_response.set_missing_fields(wrong_fields)
+            return api_response.return_bad_request_missing_fields()
+
+        dbi = get_db()
+
+        # User
+        user = get_active_user_from_request(request_data, dbi.session)
+        if not isinstance(user, UserModel):
+            return api_response.return_unauthorized()
+
+        # Permissions
+        if user.role not in USER_ROLES_WRITE_PERMISSIONS:
+            return api_response.return_unauthorized()
+
+        # Document
+        document = dbi.session.query(DocumentModel).filter(DocumentModel.id == request_data["id"]).one()
+        if not document:
+            return api_response.return_not_found()
+
+        if document.is_used(dbi.session):
+            api_response.set_message("Document is used and cannot be deleted")
+            return api_response.return_bad_request()
+
+        dbi.session.delete(document)
+        dbi.session.commit()
         return api_response.return_ok()
 
 

--- a/api/test/test_document.py
+++ b/api/test/test_document.py
@@ -1,0 +1,242 @@
+import pytest
+from http import HTTPStatus
+
+from db.models.user import UserModel
+from db.models.document import DocumentModel
+from db.models.api_document import ApiDocumentModel
+from db.models.api import ApiModel
+
+from conftest import (
+    UT_USER_EMAIL,
+    AuthActions,
+)
+
+_DOCUMENTS_URL = '/documents'
+
+_UT_GUEST_NAME = 'ut_guest_name'
+_UT_GUEST_EMAIL = 'ut_guest_email'
+_UT_GUEST_PASSWORD = 'ut_guest_password'
+
+
+@pytest.fixture(scope="module")
+def guest_user_db(client_db):
+    from db import db_orm
+    dbi = db_orm.DbInterface('test')
+    guest = UserModel(_UT_GUEST_NAME, _UT_GUEST_EMAIL, _UT_GUEST_PASSWORD, 'GUEST')
+    dbi.session.add(guest)
+    dbi.session.commit()
+    yield guest
+
+
+@pytest.fixture(scope="module")
+def guest_authentication(client, guest_user_db):
+    auth = AuthActions(client)
+    return auth.login(email=_UT_GUEST_EMAIL, password=_UT_GUEST_PASSWORD)
+
+
+@pytest.fixture()
+def unused_document_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+    d = DocumentModel(
+        title=f'Unused document #{utilities.generate_random_hex_string8()}',
+        description='A test document',
+        document_type='file',
+        spdx_relation='DESCRIBES',
+        url='https://example.com/doc',
+        section='',
+        offset=-1,
+        valid=-1,
+        created_by=user,
+    )
+    client_db.session.add(d)
+    client_db.session.commit()
+    yield d
+
+
+@pytest.fixture()
+def used_document_db(client_db, ut_user_db, utilities):
+    """Create a document that is mapped to an API (i.e. in use)."""
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+
+    d = DocumentModel(
+        title=f'Used document #{utilities.generate_random_hex_string8()}',
+        description='A test document in use',
+        document_type='file',
+        spdx_relation='DESCRIBES',
+        url='https://example.com/doc-used',
+        section='',
+        offset=-1,
+        valid=-1,
+        created_by=user,
+    )
+    api = ApiModel(
+        f'ut_api_{utilities.generate_random_hex_string8()}',
+        'ut_lib', 'v1', 'stub.md', 'ut_cat',
+        utilities.generate_random_hex_string8(),
+        'stub.impl', 0, 42, 'ut_tags', user,
+    )
+    client_db.session.add(d)
+    client_db.session.add(api)
+    client_db.session.flush()
+
+    mapping = ApiDocumentModel(api, d, 'section', 0, 100, user)
+    client_db.session.add(mapping)
+    client_db.session.commit()
+    yield d
+
+
+# ------------------------------------------------------------------
+# GET
+# ------------------------------------------------------------------
+
+def test_login(user_authentication):
+    assert user_authentication.status_code == HTTPStatus.OK
+
+
+def test_get_documents_ok(client, unused_document_db):
+    response = client.get(_DOCUMENTS_URL)
+    assert response.status_code == HTTPStatus.OK
+    assert isinstance(response.json, list)
+    assert len(response.json) > 0
+
+
+def test_get_documents_fields(client, unused_document_db):
+    response = client.get(_DOCUMENTS_URL)
+    assert response.status_code == HTTPStatus.OK
+    doc = next(
+        (d for d in response.json if d['id'] == unused_document_db.id),
+        None,
+    )
+    assert doc is not None
+    assert 'id' in doc
+    assert 'title' in doc
+    assert 'description' in doc
+    assert 'document_type' in doc
+    assert 'status' in doc
+    assert 'created_by' in doc
+    assert 'version' in doc
+    assert 'used' in doc
+
+
+def test_get_documents_used_flag_false(client, unused_document_db):
+    response = client.get(
+        _DOCUMENTS_URL,
+        query_string={'field1': 'id', 'filter1': unused_document_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is False
+
+
+def test_get_documents_used_flag_true(client, used_document_db):
+    response = client.get(
+        _DOCUMENTS_URL,
+        query_string={'field1': 'id', 'filter1': used_document_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is True
+
+
+# ------------------------------------------------------------------
+# DELETE
+# ------------------------------------------------------------------
+
+def test_delete_missing_auth_fields(client, unused_document_db):
+    response = client.delete(
+        _DOCUMENTS_URL,
+        json={'id': unused_document_db.id},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_invalid_token(client, user_authentication, unused_document_db):
+    response = client.delete(
+        _DOCUMENTS_URL,
+        json={
+            'id': unused_document_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': 'invalid-token',
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_delete_guest_forbidden(client, guest_authentication, unused_document_db):
+    response = client.delete(
+        _DOCUMENTS_URL,
+        json={
+            'id': unused_document_db.id,
+            'user-id': guest_authentication.json['id'],
+            'token': guest_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize('missing_field', ['id', 'user-id', 'token'])
+def test_delete_missing_mandatory_field(client, user_authentication, unused_document_db, missing_field):
+    data = {
+        'id': unused_document_db.id,
+        'user-id': user_authentication.json['id'],
+        'token': user_authentication.json['token'],
+    }
+    data.pop(missing_field)
+    response = client.delete(_DOCUMENTS_URL, json=data)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_used_document(client, user_authentication, used_document_db):
+    response = client.delete(
+        _DOCUMENTS_URL,
+        json={
+            'id': used_document_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_nonexistent_document(client, user_authentication):
+    from sqlalchemy.exc import NoResultFound
+    non_existent_id = 99999
+    with pytest.raises(NoResultFound):
+        client.delete(
+            _DOCUMENTS_URL,
+            json={
+                'id': non_existent_id,
+                'user-id': user_authentication.json['id'],
+                'token': user_authentication.json['token'],
+            },
+        )
+
+
+def test_delete_ok(client, client_db, user_authentication, unused_document_db):
+    document_id = unused_document_db.id
+
+    response = client.get(
+        _DOCUMENTS_URL,
+        query_string={'field1': 'id', 'filter1': document_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+
+    response = client.delete(
+        _DOCUMENTS_URL,
+        json={
+            'id': document_id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    response = client.get(
+        _DOCUMENTS_URL,
+        query_string={'field1': 'id', 'filter1': document_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 0

--- a/app/src/app/Mapping/Search/DocumentSearch.tsx
+++ b/app/src/app/Mapping/Search/DocumentSearch.tsx
@@ -12,9 +12,11 @@ import {
   HelperTextItem,
   Hint,
   HintBody,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@patternfly/react-core'
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow, SearchInput } from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
 import { useAuth } from '@app/User/AuthProvider'
 
 export interface DocumentSearchProps {
@@ -62,11 +64,48 @@ export const DocumentSearch: React.FunctionComponent<DocumentSearchProps> = ({
   const [initializedValue, setInitializedValue] = React.useState(false)
   const [coverageValue, setCoverageValue] = React.useState(formData?.coverage || 0)
   const [validatedCoverageValue, setValidatedCoverageValue] = React.useState<Constants.validate>('error')
+  const [confirmDeleteId, setConfirmDeleteId] = React.useState<number | null>(null)
 
   const resetForm = () => {
     setSelectedDataListItemId('')
     setCoverageValue('0')
     setSearchValue('')
+  }
+
+  const handleDeleteDocument = (documentId: number) => {
+    if (confirmDeleteId !== documentId) {
+      setConfirmDeleteId(documentId)
+      return
+    }
+    setConfirmDeleteId(null)
+
+    const data = {
+      id: documentId,
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(Constants.API_BASE_URL + Constants.API_DOCUMENTS_ROOT_ENDPOINT, {
+      method: 'DELETE',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        const status = response.status
+        const status_text = response.statusText
+        if (Constants.isHttpSuccessStatus(status)) {
+          setMessageValue('Document deleted with success.')
+          loadDocuments(searchValue)
+          return
+        } else {
+          return response.text().then((text) => {
+            setMessageValue(Constants.getResponseErrorMessage(status, status_text, text))
+          })
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
   }
 
   const onChangeSearchValue = (value) => {
@@ -75,10 +114,12 @@ export const DocumentSearch: React.FunctionComponent<DocumentSearchProps> = ({
 
   const onSelectDataListItem = (_event: React.MouseEvent | React.KeyboardEvent, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   React.useEffect(() => {
@@ -119,7 +160,41 @@ export const DocumentSearch: React.FunctionComponent<DocumentSearchProps> = ({
                 <span id={'clickable-action-item-' + curr_document.id}>
                   {curr_document.id} - {curr_document.title} - {curr_document.document_type} - {curr_document.spdx_relation}
                 </span>
-              </DataListCell>
+              </DataListCell>,
+              ...(auth.isLogged() && !auth.isGuest()
+                ? [
+                    <DataListCell key={`delete-${curr_document.id}`} alignRight isFilled={false}>
+                      {curr_document.used ? (
+                        <Tooltip content='Cannot delete: document is in use'>
+                          <div>
+                            <Button
+                              id={`btn-delete-document-${curr_document.id}`}
+                              variant='plain'
+                              aria-label='Cannot delete document'
+                              isDisabled
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </div>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={confirmDeleteId === curr_document.id ? 'Click again to confirm' : 'Delete document'}>
+                          <Button
+                            id={`btn-delete-document-${curr_document.id}`}
+                            variant={confirmDeleteId === curr_document.id ? 'danger' : 'plain'}
+                            aria-label='Delete document'
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDeleteDocument(curr_document.id)
+                            }}
+                          >
+                            <TrashIcon /> {confirmDeleteId === curr_document.id ? ' Confirm?' : ''}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </DataListCell>
+                  ]
+                : [])
             ]}
           />
         </DataListItemRow>

--- a/db/models/document.py
+++ b/db/models/document.py
@@ -63,6 +63,19 @@ class DocumentModel(Base):
                      DocumentHistoryModel.version.desc()).limit(1).all()[0]
         return f'{last_item.version}'
 
+    def is_used(self, db_session) -> bool:
+        if db_session is None:
+            return True
+        from db.models.api_document import ApiDocumentModel
+        from db.models.document_document import DocumentDocumentModel
+        api_documents = db_session.query(ApiDocumentModel).filter(
+            ApiDocumentModel.document_id == self.id).all()
+        if len(api_documents) > 0:
+            return True
+        doc_documents = db_session.query(DocumentDocumentModel).filter(
+            DocumentDocumentModel.document_id == self.id).all()
+        return len(doc_documents) > 0
+
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
                  "title": self.title,
@@ -79,6 +92,7 @@ class DocumentModel(Base):
 
         if db_session:
             _dict['version'] = self.current_version(db_session)
+            _dict['used'] = self.is_used(db_session)
 
         if full_data:
             _dict["created_at"] = self.created_at.strftime(Base.dt_format_str)


### PR DESCRIPTION
- Allow users to delete document work items that are not used in any mapping.
- Add `is_used` method to DocumentModel checking both ApiDocumentModel and DocumentDocumentModel references, expose `used` flag in as_dict
- Add DELETE handler on /documents endpoint
- Add a trash-icon button with confirm-click in DocumentSearch component.