### PR TITLE
Add delete support for Test Specification work items

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5834,7 +5834,7 @@ class TestSpecification(Resource):
 
         query = dbi.session.query(TestSpecificationModel)
         query = filter_query(query, request_data, TestSpecificationModel, False)
-        tss = [ts.as_dict() for ts in query.all()]
+        tss = [ts.as_dict(db_session=dbi.session) for ts in query.all()]
 
         if "mode" in request_data.keys():
             if request_data["mode"] == "minimal":
@@ -5842,6 +5842,41 @@ class TestSpecification(Resource):
                 tss = [{key: val for key, val in sub.items() if key in minimal_keys} for sub in tss]
 
         api_response.set_data(tss)
+        return api_response.return_ok()
+
+    @api_response_decorator
+    def delete(self, api_response: ApiResponse = None):
+        request_data = request.get_json(force=True)
+        mandatory_fields = ["id", "user-id", "token"]
+
+        wrong_fields = get_wrong_mandatory_fields(mandatory_fields, request_data)
+        if len(wrong_fields) > 0:
+            api_response.set_missing_fields(wrong_fields)
+            return api_response.return_bad_request_missing_fields()
+
+        dbi = get_db()
+
+        # User
+        user = get_active_user_from_request(request_data, dbi.session)
+        if not isinstance(user, UserModel):
+            return api_response.return_unauthorized()
+
+        # Permissions
+        if user.role not in USER_ROLES_WRITE_PERMISSIONS:
+            return api_response.return_unauthorized()
+
+        # Test Specification
+        test_specification = dbi.session.query(TestSpecificationModel).filter(
+            TestSpecificationModel.id == request_data["id"]).one()
+        if not test_specification:
+            return api_response.return_not_found()
+
+        if test_specification.is_used(dbi.session):
+            api_response.set_message("Test Specification is used and cannot be deleted")
+            return api_response.return_bad_request()
+
+        dbi.session.delete(test_specification)
+        dbi.session.commit()
         return api_response.return_ok()
 
 

--- a/api/test/test_test_specification.py
+++ b/api/test/test_test_specification.py
@@ -1,0 +1,245 @@
+import pytest
+from http import HTTPStatus
+
+from db.models.user import UserModel
+from db.models.test_specification import TestSpecificationModel
+from db.models.api_test_specification import ApiTestSpecificationModel
+from db.models.api import ApiModel
+
+from conftest import (
+    UT_USER_EMAIL,
+    AuthActions,
+)
+
+_TEST_SPECIFICATIONS_URL = '/test-specifications'
+
+_UT_GUEST_NAME = 'ut_ts_guest_name'
+_UT_GUEST_EMAIL = 'ut_ts_guest_email'
+_UT_GUEST_PASSWORD = 'ut_ts_guest_password'
+
+
+@pytest.fixture(scope="module")
+def guest_user_db(client_db):
+    from db import db_orm
+    dbi = db_orm.DbInterface('test')
+    guest = UserModel(_UT_GUEST_NAME, _UT_GUEST_EMAIL, _UT_GUEST_PASSWORD, 'GUEST')
+    dbi.session.add(guest)
+    dbi.session.commit()
+    yield guest
+
+
+@pytest.fixture(scope="module")
+def guest_authentication(client, guest_user_db):
+    auth = AuthActions(client)
+    return auth.login(email=_UT_GUEST_EMAIL, password=_UT_GUEST_PASSWORD)
+
+
+@pytest.fixture()
+def unused_test_specification_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+    ts = TestSpecificationModel(
+        f'Unused TS #{utilities.generate_random_hex_string8()}',
+        'preconditions',
+        'test description',
+        'expected behavior',
+        user,
+    )
+    client_db.session.add(ts)
+    client_db.session.commit()
+    yield ts
+
+
+@pytest.fixture()
+def used_test_specification_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+
+    ts = TestSpecificationModel(
+        f'Used TS #{utilities.generate_random_hex_string8()}',
+        'preconditions',
+        'test description',
+        'expected behavior',
+        user,
+    )
+    api = ApiModel(
+        f'ut_api_{utilities.generate_random_hex_string8()}',
+        'ut_lib', 'v1', 'stub.md', 'ut_cat',
+        utilities.generate_random_hex_string8(),
+        'stub.impl', 0, 42, 'ut_tags', user,
+    )
+    client_db.session.add(ts)
+    client_db.session.add(api)
+    client_db.session.flush()
+
+    mapping = ApiTestSpecificationModel(api, ts, 'section', 0, 0, user)
+    client_db.session.add(mapping)
+    client_db.session.commit()
+    yield ts
+
+
+# ------------------------------------------------------------------
+# GET
+# ------------------------------------------------------------------
+
+def test_login(user_authentication):
+    assert user_authentication.status_code == HTTPStatus.OK
+
+
+def test_get_test_specifications_ok(client, unused_test_specification_db):
+    response = client.get(_TEST_SPECIFICATIONS_URL)
+    assert response.status_code == HTTPStatus.OK
+    assert isinstance(response.json, list)
+    assert len(response.json) > 0
+
+
+def test_get_test_specifications_fields(client, unused_test_specification_db):
+    response = client.get(_TEST_SPECIFICATIONS_URL)
+    assert response.status_code == HTTPStatus.OK
+    ts = next(
+        (t for t in response.json if t['id'] == unused_test_specification_db.id),
+        None,
+    )
+    assert ts is not None
+    assert 'id' in ts
+    assert 'title' in ts
+    assert 'preconditions' in ts
+    assert 'test_description' in ts
+    assert 'expected_behavior' in ts
+    assert 'status' in ts
+    assert 'created_by' in ts
+    assert 'version' in ts
+    assert 'used' in ts
+
+
+def test_get_test_specifications_used_flag_false(client, unused_test_specification_db):
+    response = client.get(
+        _TEST_SPECIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': unused_test_specification_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is False
+
+
+def test_get_test_specifications_used_flag_true(client, used_test_specification_db):
+    response = client.get(
+        _TEST_SPECIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': used_test_specification_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is True
+
+
+def test_get_test_specifications_minimal_mode(client, unused_test_specification_db):
+    response = client.get(
+        _TEST_SPECIFICATIONS_URL,
+        query_string={'mode': 'minimal'},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) > 0
+    for ts in response.json:
+        assert set(ts.keys()) == {'id', 'title'}
+
+
+# ------------------------------------------------------------------
+# DELETE
+# ------------------------------------------------------------------
+
+def test_delete_missing_auth_fields(client, unused_test_specification_db):
+    response = client.delete(
+        _TEST_SPECIFICATIONS_URL,
+        json={'id': unused_test_specification_db.id},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_invalid_token(client, user_authentication, unused_test_specification_db):
+    response = client.delete(
+        _TEST_SPECIFICATIONS_URL,
+        json={
+            'id': unused_test_specification_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': 'invalid-token',
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_delete_guest_forbidden(client, guest_authentication, unused_test_specification_db):
+    response = client.delete(
+        _TEST_SPECIFICATIONS_URL,
+        json={
+            'id': unused_test_specification_db.id,
+            'user-id': guest_authentication.json['id'],
+            'token': guest_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize('missing_field', ['id', 'user-id', 'token'])
+def test_delete_missing_mandatory_field(client, user_authentication, unused_test_specification_db, missing_field):
+    data = {
+        'id': unused_test_specification_db.id,
+        'user-id': user_authentication.json['id'],
+        'token': user_authentication.json['token'],
+    }
+    data.pop(missing_field)
+    response = client.delete(_TEST_SPECIFICATIONS_URL, json=data)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_used_test_specification(client, user_authentication, used_test_specification_db):
+    response = client.delete(
+        _TEST_SPECIFICATIONS_URL,
+        json={
+            'id': used_test_specification_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_nonexistent_test_specification(client, user_authentication):
+    from sqlalchemy.exc import NoResultFound
+    non_existent_id = 99999
+    with pytest.raises(NoResultFound):
+        client.delete(
+            _TEST_SPECIFICATIONS_URL,
+            json={
+                'id': non_existent_id,
+                'user-id': user_authentication.json['id'],
+                'token': user_authentication.json['token'],
+            },
+        )
+
+
+def test_delete_ok(client, client_db, user_authentication, unused_test_specification_db):
+    ts_id = unused_test_specification_db.id
+
+    response = client.get(
+        _TEST_SPECIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': ts_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+
+    response = client.delete(
+        _TEST_SPECIFICATIONS_URL,
+        json={
+            'id': ts_id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    response = client.get(
+        _TEST_SPECIFICATIONS_URL,
+        query_string={'field1': 'id', 'filter1': ts_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 0

--- a/app/src/app/Mapping/Search/TestSpecificationSearch.tsx
+++ b/app/src/app/Mapping/Search/TestSpecificationSearch.tsx
@@ -12,9 +12,11 @@ import {
   HelperTextItem,
   Hint,
   HintBody,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@patternfly/react-core'
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow, SearchInput } from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
 import { useAuth } from '@app/User/AuthProvider'
 
 export interface TestSpecificationSearchProps {
@@ -62,11 +64,48 @@ export const TestSpecificationSearch: React.FunctionComponent<TestSpecificationS
   const [initializedValue, setInitializedValue] = React.useState(false)
   const [coverageValue, setCoverageValue] = React.useState(formData.coverage || 0)
   const [validatedCoverageValue, setValidatedCoverageValue] = React.useState('error')
+  const [confirmDeleteId, setConfirmDeleteId] = React.useState<number | null>(null)
 
   const resetForm = () => {
     setSelectedDataListItemId('')
     setCoverageValue(0)
     setSearchValue('')
+  }
+
+  const handleDeleteTestSpecification = (testSpecificationId: number) => {
+    if (confirmDeleteId !== testSpecificationId) {
+      setConfirmDeleteId(testSpecificationId)
+      return
+    }
+    setConfirmDeleteId(null)
+
+    const data = {
+      id: testSpecificationId,
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(Constants.API_BASE_URL + Constants.API_TEST_SPECIFICATIONS_ROOT_ENDPOINT, {
+      method: 'DELETE',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        const status = response.status
+        const status_text = response.statusText
+        if (Constants.isHttpSuccessStatus(status)) {
+          setMessageValue('Test Specification deleted with success.')
+          loadTestSpecifications(searchValue)
+          return
+        } else {
+          return response.text().then((text) => {
+            setMessageValue(Constants.getResponseErrorMessage(status, status_text, text))
+          })
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
   }
 
   React.useEffect(() => {
@@ -83,10 +122,12 @@ export const TestSpecificationSearch: React.FunctionComponent<TestSpecificationS
 
   const onSelectDataListItem = (_event: React.MouseEvent | React.KeyboardEvent, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const getTestSpecificationsTable = (test_specifications) => {
@@ -104,7 +145,43 @@ export const TestSpecificationSearch: React.FunctionComponent<TestSpecificationS
                 <span id={'clickable-action-item-' + test_specification.id}>
                   {test_specification.id} - {test_specification.title}
                 </span>
-              </DataListCell>
+              </DataListCell>,
+              ...(auth.isLogged() && !auth.isGuest()
+                ? [
+                    <DataListCell key={`delete-${test_specification.id}`} alignRight isFilled={false}>
+                      {test_specification.used ? (
+                        <Tooltip content='Cannot delete: test specification is in use'>
+                          <div>
+                            <Button
+                              id={`btn-delete-test-specification-${test_specification.id}`}
+                              variant='plain'
+                              aria-label='Cannot delete test specification'
+                              isDisabled
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </div>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip
+                          content={confirmDeleteId === test_specification.id ? 'Click again to confirm' : 'Delete test specification'}
+                        >
+                          <Button
+                            id={`btn-delete-test-specification-${test_specification.id}`}
+                            variant={confirmDeleteId === test_specification.id ? 'danger' : 'plain'}
+                            aria-label='Delete test specification'
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDeleteTestSpecification(test_specification.id)
+                            }}
+                          >
+                            <TrashIcon /> {confirmDeleteId === test_specification.id ? ' Confirm?' : ''}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </DataListCell>
+                  ]
+                : [])
             ]}
           />
         </DataListItemRow>

--- a/db/models/test_specification.py
+++ b/db/models/test_specification.py
@@ -57,6 +57,19 @@ class TestSpecificationModel(Base):
                      TestSpecificationHistoryModel.version.desc()).limit(1).all()[0]
         return f'{last_item.version}'
 
+    def is_used(self, db_session) -> bool:
+        if db_session is None:
+            return True
+        from db.models.api_test_specification import ApiTestSpecificationModel
+        from db.models.sw_requirement_test_specification import SwRequirementTestSpecificationModel
+        api_mappings = db_session.query(ApiTestSpecificationModel).filter(
+            ApiTestSpecificationModel.test_specification_id == self.id).all()
+        if len(api_mappings) > 0:
+            return True
+        sr_mappings = db_session.query(SwRequirementTestSpecificationModel).filter(
+            SwRequirementTestSpecificationModel.test_specification_id == self.id).all()
+        return len(sr_mappings) > 0
+
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
                  "title": self.title,
@@ -69,6 +82,7 @@ class TestSpecificationModel(Base):
 
         if db_session is not None:
             _dict['version'] = self.current_version(db_session)
+            _dict['used'] = self.is_used(db_session)
 
         if full_data:
             _dict["created_at"] = self.created_at.strftime(Base.dt_format_str)


### PR DESCRIPTION
Allow users to delete Test Specifications that are not mapped to any API or Software Requirement. 
Follows the same pattern used for Justification delete: model exposes is_used/used flag, API enforces the guard, and the UI shows a trash icon with confirmation.