### PR TITLE
Add Test Case delete endpoint and UI delete button

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5886,7 +5886,7 @@ class TestCase(Resource):
         dbi = get_db()
         query = dbi.session.query(TestCaseModel)
         query = filter_query(query, request_data, TestCaseModel, False)
-        tcs = [tc.as_dict() for tc in query.all()]
+        tcs = [tc.as_dict(db_session=dbi.session) for tc in query.all()]
 
         if "mode" in request_data.keys():
             if request_data["mode"] == "minimal":
@@ -5894,6 +5894,40 @@ class TestCase(Resource):
                 tcs = [{key: val for key, val in sub.items() if key in minimal_keys} for sub in tcs]
 
         api_response.set_data(tcs)
+        return api_response.return_ok()
+
+    @api_response_decorator
+    def delete(self, api_response: ApiResponse = None):
+        request_data = request.get_json(force=True)
+        mandatory_fields = ["id", "user-id", "token"]
+
+        wrong_fields = get_wrong_mandatory_fields(mandatory_fields, request_data)
+        if len(wrong_fields) > 0:
+            api_response.set_missing_fields(wrong_fields)
+            return api_response.return_bad_request_missing_fields()
+
+        dbi = get_db()
+
+        # User
+        user = get_active_user_from_request(request_data, dbi.session)
+        if not isinstance(user, UserModel):
+            return api_response.return_unauthorized()
+
+        # Permissions
+        if user.role not in USER_ROLES_WRITE_PERMISSIONS:
+            return api_response.return_unauthorized()
+
+        # Test Case
+        test_case = dbi.session.query(TestCaseModel).filter(TestCaseModel.id == request_data["id"]).one()
+        if not test_case:
+            return api_response.return_not_found()
+
+        if test_case.is_used(dbi.session):
+            api_response.set_message("Test Case is used and cannot be deleted")
+            return api_response.return_bad_request()
+
+        dbi.session.delete(test_case)
+        dbi.session.commit()
         return api_response.return_ok()
 
 

--- a/api/test/test_test_case.py
+++ b/api/test/test_test_case.py
@@ -1,0 +1,246 @@
+import pytest
+from http import HTTPStatus
+
+from db.models.user import UserModel
+from db.models.test_case import TestCaseModel
+from db.models.api_test_case import ApiTestCaseModel
+from db.models.api import ApiModel
+
+from conftest import (
+    UT_USER_EMAIL,
+    AuthActions,
+)
+
+_TEST_CASES_URL = '/test-cases'
+
+_UT_GUEST_NAME = 'ut_tc_guest_name'
+_UT_GUEST_EMAIL = 'ut_tc_guest_email'
+_UT_GUEST_PASSWORD = 'ut_tc_guest_password'
+
+
+@pytest.fixture(scope="module")
+def guest_user_db(client_db):
+    from db import db_orm
+    dbi = db_orm.DbInterface('test')
+    guest = UserModel(_UT_GUEST_NAME, _UT_GUEST_EMAIL, _UT_GUEST_PASSWORD, 'GUEST')
+    dbi.session.add(guest)
+    dbi.session.commit()
+    yield guest
+
+
+@pytest.fixture(scope="module")
+def guest_authentication(client, guest_user_db):
+    auth = AuthActions(client)
+    return auth.login(email=_UT_GUEST_EMAIL, password=_UT_GUEST_PASSWORD)
+
+
+@pytest.fixture()
+def unused_test_case_db(client_db, ut_user_db, utilities):
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+    tc = TestCaseModel(
+        'https://example.com/repo',
+        'tests/test_example.py',
+        f'Unused TC #{utilities.generate_random_hex_string8()}',
+        'A test case not mapped anywhere',
+        user,
+    )
+    client_db.session.add(tc)
+    client_db.session.commit()
+    yield tc
+
+
+@pytest.fixture()
+def used_test_case_db(client_db, ut_user_db, utilities):
+    """Create a test case that is mapped to an API (i.e. in use)."""
+    user = client_db.session.query(UserModel).filter(
+        UserModel.email == UT_USER_EMAIL).one()
+
+    tc = TestCaseModel(
+        'https://example.com/repo',
+        'tests/test_used.py',
+        f'Used TC #{utilities.generate_random_hex_string8()}',
+        'A test case mapped to an API',
+        user,
+    )
+    api = ApiModel(
+        f'ut_api_{utilities.generate_random_hex_string8()}',
+        'ut_lib', 'v1', 'stub.md', 'ut_cat',
+        utilities.generate_random_hex_string8(),
+        'stub.impl', 0, 42, 'ut_tags', user,
+    )
+    client_db.session.add(tc)
+    client_db.session.add(api)
+    client_db.session.flush()
+
+    mapping = ApiTestCaseModel(api, tc, 'section', 0, 0, user)
+    client_db.session.add(mapping)
+    client_db.session.commit()
+    yield tc
+
+
+# ------------------------------------------------------------------
+# GET
+# ------------------------------------------------------------------
+
+def test_login(user_authentication):
+    assert user_authentication.status_code == HTTPStatus.OK
+
+
+def test_get_test_cases_ok(client, unused_test_case_db):
+    response = client.get(_TEST_CASES_URL)
+    assert response.status_code == HTTPStatus.OK
+    assert isinstance(response.json, list)
+    assert len(response.json) > 0
+
+
+def test_get_test_cases_fields(client, unused_test_case_db):
+    response = client.get(_TEST_CASES_URL)
+    assert response.status_code == HTTPStatus.OK
+    test_case = next(
+        (tc for tc in response.json if tc['id'] == unused_test_case_db.id),
+        None,
+    )
+    assert test_case is not None
+    assert 'id' in test_case
+    assert 'title' in test_case
+    assert 'description' in test_case
+    assert 'repository' in test_case
+    assert 'relative_path' in test_case
+    assert 'status' in test_case
+    assert 'created_by' in test_case
+    assert 'version' in test_case
+    assert 'used' in test_case
+
+
+def test_get_test_cases_used_flag_false(client, unused_test_case_db):
+    response = client.get(
+        _TEST_CASES_URL,
+        query_string={'field1': 'id', 'filter1': unused_test_case_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is False
+
+
+def test_get_test_cases_used_flag_true(client, used_test_case_db):
+    response = client.get(
+        _TEST_CASES_URL,
+        query_string={'field1': 'id', 'filter1': used_test_case_db.id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+    assert response.json[0]['used'] is True
+
+
+def test_get_test_cases_minimal_mode(client, unused_test_case_db):
+    response = client.get(
+        _TEST_CASES_URL,
+        query_string={'mode': 'minimal'},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) > 0
+    for tc in response.json:
+        assert set(tc.keys()) == {'id', 'title'}
+
+
+# ------------------------------------------------------------------
+# DELETE
+# ------------------------------------------------------------------
+
+def test_delete_missing_auth_fields(client, unused_test_case_db):
+    response = client.delete(
+        _TEST_CASES_URL,
+        json={'id': unused_test_case_db.id},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_invalid_token(client, user_authentication, unused_test_case_db):
+    response = client.delete(
+        _TEST_CASES_URL,
+        json={
+            'id': unused_test_case_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': 'invalid-token',
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_delete_guest_forbidden(client, guest_authentication, unused_test_case_db):
+    response = client.delete(
+        _TEST_CASES_URL,
+        json={
+            'id': unused_test_case_db.id,
+            'user-id': guest_authentication.json['id'],
+            'token': guest_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize('missing_field', ['id', 'user-id', 'token'])
+def test_delete_missing_mandatory_field(client, user_authentication, unused_test_case_db, missing_field):
+    data = {
+        'id': unused_test_case_db.id,
+        'user-id': user_authentication.json['id'],
+        'token': user_authentication.json['token'],
+    }
+    data.pop(missing_field)
+    response = client.delete(_TEST_CASES_URL, json=data)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_used_test_case(client, user_authentication, used_test_case_db):
+    response = client.delete(
+        _TEST_CASES_URL,
+        json={
+            'id': used_test_case_db.id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_delete_nonexistent_test_case(client, user_authentication):
+    from sqlalchemy.exc import NoResultFound
+    non_existent_id = 99999
+    with pytest.raises(NoResultFound):
+        client.delete(
+            _TEST_CASES_URL,
+            json={
+                'id': non_existent_id,
+                'user-id': user_authentication.json['id'],
+                'token': user_authentication.json['token'],
+            },
+        )
+
+
+def test_delete_ok(client, client_db, user_authentication, unused_test_case_db):
+    test_case_id = unused_test_case_db.id
+
+    response = client.get(
+        _TEST_CASES_URL,
+        query_string={'field1': 'id', 'filter1': test_case_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 1
+
+    response = client.delete(
+        _TEST_CASES_URL,
+        json={
+            'id': test_case_id,
+            'user-id': user_authentication.json['id'],
+            'token': user_authentication.json['token'],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    response = client.get(
+        _TEST_CASES_URL,
+        query_string={'field1': 'id', 'filter1': test_case_id},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert len(response.json) == 0

--- a/app/src/app/Mapping/Search/TestCaseSearch.tsx
+++ b/app/src/app/Mapping/Search/TestCaseSearch.tsx
@@ -12,9 +12,11 @@ import {
   HelperTextItem,
   Hint,
   HintBody,
-  TextInput
+  TextInput,
+  Tooltip
 } from '@patternfly/react-core'
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow, SearchInput } from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
 import { useAuth } from '@app/User/AuthProvider'
 
 export interface TestCaseSearchProps {
@@ -62,11 +64,48 @@ export const TestCaseSearch: React.FunctionComponent<TestCaseSearchProps> = ({
   const [initializedValue, setInitializedValue] = React.useState(false)
   const [coverageValue, setCoverageValue] = React.useState(formData.coverage || 0)
   const [validatedCoverageValue, setValidatedCoverageValue] = React.useState('error')
+  const [confirmDeleteId, setConfirmDeleteId] = React.useState<number | null>(null)
 
   const resetForm = () => {
     setSelectedDataListItemId('')
     setCoverageValue(0)
     setSearchValue('')
+  }
+
+  const handleDeleteTestCase = (testCaseId: number) => {
+    if (confirmDeleteId !== testCaseId) {
+      setConfirmDeleteId(testCaseId)
+      return
+    }
+    setConfirmDeleteId(null)
+
+    const data = {
+      id: testCaseId,
+      'user-id': auth.userId,
+      token: auth.token
+    }
+
+    fetch(Constants.API_BASE_URL + Constants.API_TEST_CASES_ROOT_ENDPOINT, {
+      method: 'DELETE',
+      headers: Constants.JSON_HEADER,
+      body: JSON.stringify(data)
+    })
+      .then((response) => {
+        const status = response.status
+        const status_text = response.statusText
+        if (Constants.isHttpSuccessStatus(status)) {
+          setMessageValue('Test Case deleted with success.')
+          loadTestCases(searchValue)
+          return
+        } else {
+          return response.text().then((text) => {
+            setMessageValue(Constants.getResponseErrorMessage(status, status_text, text))
+          })
+        }
+      })
+      .catch((err) => {
+        setMessageValue(err.toString())
+      })
   }
 
   React.useEffect(() => {
@@ -83,10 +122,12 @@ export const TestCaseSearch: React.FunctionComponent<TestCaseSearchProps> = ({
 
   const onSelectDataListItem = (_event: React.MouseEvent | React.KeyboardEvent, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, id: string) => {
     setSelectedDataListItemId(id)
+    setConfirmDeleteId(null)
   }
 
   const getTestCasesTable = (test_cases) => {
@@ -104,7 +145,41 @@ export const TestCaseSearch: React.FunctionComponent<TestCaseSearchProps> = ({
                 <span id={'clickable-action-item-' + test_case.id}>
                   {test_case.id} - {test_case.title}
                 </span>
-              </DataListCell>
+              </DataListCell>,
+              ...(auth.isLogged() && !auth.isGuest()
+                ? [
+                    <DataListCell key={`delete-${test_case.id}`} alignRight isFilled={false}>
+                      {test_case.used ? (
+                        <Tooltip content='Cannot delete: test case is in use'>
+                          <div>
+                            <Button
+                              id={`btn-delete-test-case-${test_case.id}`}
+                              variant='plain'
+                              aria-label='Cannot delete test case'
+                              isDisabled
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </div>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={confirmDeleteId === test_case.id ? 'Click again to confirm' : 'Delete test case'}>
+                          <Button
+                            id={`btn-delete-test-case-${test_case.id}`}
+                            variant={confirmDeleteId === test_case.id ? 'danger' : 'plain'}
+                            aria-label='Delete test case'
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleDeleteTestCase(test_case.id)
+                            }}
+                          >
+                            <TrashIcon /> {confirmDeleteId === test_case.id ? ' Confirm?' : ''}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </DataListCell>
+                  ]
+                : [])
             ]}
           />
         </DataListItemRow>

--- a/db/models/test_case.py
+++ b/db/models/test_case.py
@@ -56,6 +56,20 @@ class TestCaseModel(Base):
                      TestCaseHistoryModel.version.desc()).limit(1).all()[0]
         return f'{last_item.version}'
 
+    def is_used(self, db_session) -> bool:
+        if db_session is None:
+            return True
+        from db.models.api_test_case import ApiTestCaseModel
+        from db.models.sw_requirement_test_case import SwRequirementTestCaseModel
+        from db.models.test_specification_test_case import TestSpecificationTestCaseModel
+        api_tcs = db_session.query(ApiTestCaseModel).filter(
+            ApiTestCaseModel.test_case_id == self.id).all()
+        sr_tcs = db_session.query(SwRequirementTestCaseModel).filter(
+            SwRequirementTestCaseModel.test_case_id == self.id).all()
+        ts_tcs = db_session.query(TestSpecificationTestCaseModel).filter(
+            TestSpecificationTestCaseModel.test_case_id == self.id).all()
+        return len(api_tcs) + len(sr_tcs) + len(ts_tcs) > 0
+
     def as_dict(self, full_data=False, db_session=None):
         _dict = {"id": self.id,
                  "repository": self.repository,
@@ -68,6 +82,7 @@ class TestCaseModel(Base):
 
         if db_session:
             _dict['version'] = self.current_version(db_session)
+            _dict['used'] = self.is_used(db_session)
 
         if full_data:
             _dict["created_at"] = self.created_at.strftime(Base.dt_format_str)


### PR DESCRIPTION
Allow users to delete Test Case work items that are not referenced by any mapping (api, sw-requirement, or test-specification).

Changes:
- db/models/test_case.py: add `is_used()` method that checks whether the test case is referenced in ApiTestCaseModel, SwRequirementTestCaseModel, or TestSpecificationTestCaseModel; expose the result as `used` flag in `as_dict()` when a db_session is provided.
- api/api.py: pass db_session in the TestCase GET handler so the `used` and `version` fields are returned; add a DELETE handler that validates authentication, write permissions, and usage before deleting.
- app/src/app/Mapping/Search/TestCaseSearch.tsx: add a trash-icon delete button per list item — disabled with tooltip when the test case is in use, two-click confirmation otherwise. Follows the same pattern implemented for Justification work items.
- api/test/test_test_case.py: new test module covering GET field validation, used/unused flags, minimal mode, and DELETE scenarios (missing fields, invalid token, guest forbidden, used item rejection, nonexistent item, and successful deletion).