### PR TITLE
Update tmt from 1.36.0 to 1.67.0

### DIFF
--- a/misc/tmt_provision_podman.patch
+++ b/misc/tmt_provision_podman.patch
@@ -1,11 +1,11 @@
 --- steps/provision/podman.py
 +++ steps/provision/podman_modified.py
-@@ -151,7 +151,7 @@
+@@ -195,7 +195,7 @@
              else:
                  raise err
-
+ 
 -        return ['--network', self.network]
 +        return ['--network=host']
-
-     def start(self) -> None:
-         """ Start provisioned guest """
+ 
+     def _setup_environment(self) -> list[str]:
+         """

--- a/misc/tmt_provision_podman_debian.patch
+++ b/misc/tmt_provision_podman_debian.patch
@@ -1,8 +1,8 @@
 --- steps/provision/podman.py
 +++ steps/provision/podman_modified.py
-@@ -15,7 +15,7 @@ from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, field,
+@@ -34,7 +34,7 @@
  CONNECTION_TIMEOUT = 60
-
+ 
  # Defaults
 -DEFAULT_IMAGE = "fedora"
 +DEFAULT_IMAGE = "debian"

--- a/misc/tmt_provision_podman_debian_apt.patch
+++ b/misc/tmt_provision_podman_debian_apt.patch
@@ -1,9 +1,11 @@
 --- package_managers/apt.py
 +++ package_managers/apt_modified.py
-@@ -53,6 +53,7 @@ class Apt(tmt.package_managers.PackageManager):
+@@ -96,7 +96,7 @@
          return (command, options)
  
-     def _enable_apt_file(self) -> None:
-+        self.guest.execute(ShellScript(f'{self._sudo_prefix} apt update'))
-         self.install(Package('apt-file'))
-         self.guest.execute(ShellScript(f'{self._sudo_prefix} apt-file update'))
+     def _enable_apt_file(self) -> ShellScript:
+-        return ShellScript(
++        return self.refresh_metadata() & ShellScript(
+             f'( {self.install(Package("apt-file"))} ) && '
+             f'{self.guest.facts.sudo_prefix} apt-file update'
+         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "python-gitlab==3.15.0",
     "requests==2.28.2",
     "spdx3-validate==0.0.5",
-    "tmt==1.36.0",
+    "tmt==1.67.0",
     "tmt[provision-container]"
 ]
 requires-python = ">=3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pytest-cov==4.1.0
 python-gitlab==3.15.0
 requests==2.28.2
 spdx3-validate==0.0.5
-tmt==1.36.0
+tmt==1.67.0
 tmt[provision-container]
 Werkzeug==2.2.2


### PR DESCRIPTION
- Bump tmt version in requirements.txt and pyproject.toml
- Update all three tmt patches (misc/) for compatibility with 1.67.0:
  - tmt_provision_podman.patch: fix context for new _setup_environment method
  - tmt_provision_podman_debian.patch: fix context for reorganized imports
  - tmt_provision_podman_debian_apt.patch: rewrite for new AptEngine architecture, use refresh_metadata() to chain apt update before apt-file install