### PR TITLE
Rotate user token on role change to force re-login

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -9593,6 +9593,7 @@ class UserRole(Resource):
             return api_response.return_not_found_user()
 
         target_user.role = target_user_role
+        target_user.token = str(uuid4())
         dbi.session.commit()
 
         # Notification

--- a/api/test/test_user_role.py
+++ b/api/test/test_user_role.py
@@ -184,7 +184,7 @@ def test_put_rotates_target_user_token(
     response = _put_user_role(client, uid, token, ut_reader_user_db.id, "GUEST")
     assert response.status_code == HTTPStatus.OK
 
-    client_db.session.expire(ut_reader_user_db)
+    client_db.session.expire_all()
     token_after = _get_user_token(client_db, ut_reader_user_db.id)
     assert token_after != token_before
 

--- a/api/test/test_user_role.py
+++ b/api/test/test_user_role.py
@@ -56,6 +56,11 @@ def _get_user_role(client_db, user_id):
     return user.role
 
 
+def _get_user_token(client_db, user_id):
+    user = client_db.session.query(UserModel).filter(UserModel.id == user_id).one()
+    return user.token
+
+
 def test_put_ok_change_role_to_admin(
     client, admin_authentication, ut_reader_user_db, client_db
 ):
@@ -167,3 +172,20 @@ def test_put_not_found_target_user(client, admin_authentication):
     uid, token = _auth_fields(admin_authentication)
     response = _put_user_role(client, uid, token, 999_999, "USER")
     assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_put_rotates_target_user_token(
+    client, admin_authentication, ut_reader_user_db, client_db
+):
+    """Role change rotates the target user's session token to force re-login."""
+    uid, token = _auth_fields(admin_authentication)
+    token_before = _get_user_token(client_db, ut_reader_user_db.id)
+
+    response = _put_user_role(client, uid, token, ut_reader_user_db.id, "GUEST")
+    assert response.status_code == HTTPStatus.OK
+
+    client_db.session.expire(ut_reader_user_db)
+    token_after = _get_user_token(client_db, ut_reader_user_db.id)
+    assert token_after != token_before
+
+    _put_user_role(client, uid, token, ut_reader_user_db.id, "USER")


### PR DESCRIPTION
When an admin changes a user's role, regenerate the user's session token so any active sessions are invalidated and the user must log in again.

Solves #291 