### PR TITLE
Fix SPDX 3.0.1 export beginIntegerRange always set to 1 (#290)

### DIFF
--- a/api/spdx_manager.py
+++ b/api/spdx_manager.py
@@ -326,7 +326,7 @@ class PositiveIntegerRange:
     def to_dict(self):
         return {
             "type": "PositiveIntegerRange",
-            "beginIntegerRange": min(self.beginIntegerRange, 1),
+            "beginIntegerRange": max(self.beginIntegerRange, 1),
             "endIntegerRange": self.endIntegerRange,
         }
 

--- a/api/test/test_spdx_api_validation.py
+++ b/api/test/test_spdx_api_validation.py
@@ -546,6 +546,32 @@ def test_spdx_api_export_and_validation(client, user_authentication, comprehensi
         f"{len(relationships)} relationships, {len(snippets)} snippets"
     )
 
+    # Verify beginIntegerRange correctness (regression for issue #290)
+    # Every snippet byte range must respect the SPDX PositiveIntegerRange minimum of 1
+    for snippet in snippets:
+        byte_range = snippet.get("software_byteRange", {})
+        begin = byte_range.get("beginIntegerRange")
+        end = byte_range.get("endIntegerRange")
+        assert begin is not None, f"Snippet {snippet.get('spdxId')} is missing beginIntegerRange"
+        assert end is not None, f"Snippet {snippet.get('spdxId')} is missing endIntegerRange"
+        assert begin >= 1, (
+            f"Snippet {snippet.get('spdxId')} has beginIntegerRange={begin}, "
+            "must be >= 1 per SPDX PositiveIntegerRange spec"
+        )
+        assert end >= begin, (
+            f"Snippet {snippet.get('spdxId')} has endIntegerRange={end} < beginIntegerRange={begin}"
+        )
+
+    # The test fixture maps sections at different offsets in the spec, so the
+    # resulting beginIntegerRange values must NOT all be identical (if they were
+    # all 1, the bug from issue #290 would be present again).
+    begin_values = {s["software_byteRange"]["beginIntegerRange"] for s in snippets}
+    assert len(begin_values) > 1, (
+        f"All snippets share the same beginIntegerRange={begin_values}; "
+        "expected distinct values for sections at different offsets (issue #290 regression)"
+    )
+    print(f"✓ Snippet byteRange validation passed: beginIntegerRange values = {sorted(begin_values)}")
+
     """Test that all types of work items are represented in the SPDX output"""
 
     # Extract all spdxId values to check for our work items

--- a/examples/export/spdx.jsonld
+++ b/examples/export/spdx.jsonld
@@ -316,7 +316,7 @@
       "description": "",
       "software_byteRange": {
         "type": "PositiveIntegerRange",
-        "beginIntegerRange": 1,
+        "beginIntegerRange": 95,
         "endIntegerRange": 261
       },
       "software_snippetFromFile": "spdx:file:basil:api:reference-document:2",
@@ -330,7 +330,7 @@
       "description": "",
       "software_byteRange": {
         "type": "PositiveIntegerRange",
-        "beginIntegerRange": 1,
+        "beginIntegerRange": 444,
         "endIntegerRange": 597
       },
       "software_snippetFromFile": "spdx:file:basil:api:reference-document:2",


### PR DESCRIPTION
Replace min() with max() in PositiveIntegerRange.to_dict() so that each snippet's beginIntegerRange reflects the actual mapping offset instead of being clamped to 1 for every entry. 
Add regression assertions to the SPDX validation test and correct the example export file accordingly.

Solves #290 