### PR TITLE
Fix SPDX 3.0.1 opaque metadata in Annotations (#299)

### DIFF
--- a/api/spdx_manager.py
+++ b/api/spdx_manager.py
@@ -42,6 +42,7 @@ BASIL_TOOL_URL = "https://github.com/elisa-tech/BASIL"
 SPDX_CONTEXT_URL = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
 DATETIME_STR_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 SPDX_SPEC_VERSION = "3.0.1"
+BASIL_ANNOTATION_VERSION = "2.0"
 
 
 class SPDXMD5Hash:
@@ -54,6 +55,40 @@ class SPDXMD5Hash:
             "algorithm": "md5",
             "hashValue": self.hash_value,
         }
+
+
+class SPDXExternalIdentifier:
+    """Represents a SPDX 3.0.1 ExternalIdentifier inline object.
+
+    Used to expose BASIL entity IDs to standard SPDX-aware tooling without
+    relying on opaque Annotation.statement JSON.
+
+    The identifier follows the convention:
+        basil:<db_table_name>:<db_row_id>
+
+    where <db_table_name> is the SQLAlchemy __tablename__ of the originating
+    model (e.g. "sw_requirements", "test_cases") and <db_row_id> is the
+    integer primary key.  Using the table name directly keeps the identifier
+    in sync with the database schema and avoids a separate mapping layer.
+
+    Example:
+        identifier = "basil:sw_requirements:42"
+        comment    = "BASIL Software Requirement 'My Title' with ID 42"
+    """
+
+    def __init__(self, identifier: str = "", comment: str = ""):
+        self.identifier = identifier
+        self.comment = comment
+
+    def to_dict(self):
+        result = {
+            "type": "ExternalIdentifier",
+            "externalIdentifierType": "other",
+            "identifier": self.identifier,
+        }
+        if self.comment:
+            result["comment"] = self.comment
+        return result
 
 
 class SPDXCreationInfo:
@@ -217,7 +252,8 @@ class SPDXAnnotation:
         self.spdx_id = f"{spdx_id}"
         self.name = name
         self.subject = subject
-        self.statement = json.dumps(object)
+        versioned_object = {**object, "basil:annotationVersion": BASIL_ANNOTATION_VERSION}
+        self.statement = json.dumps(versioned_object)
         self.creation_info = creation_info
 
     def to_dict(self):
@@ -289,6 +325,7 @@ class SPDXFile:
         purpose: str = "",
         copyright_text: str = "",
         verified_using: List[SPDXMD5Hash] = [],
+        external_identifiers: List["SPDXExternalIdentifier"] = [],
         creation_info: SPDXCreationInfo = None,
     ):
 
@@ -299,6 +336,7 @@ class SPDXFile:
         self._purpose = purpose if purpose in self.supported_puposes else "other"
         self.copyright_text = copyright_text
         self.verified_using = verified_using
+        self.external_identifiers = external_identifiers
         self.creation_info = creation_info
 
     @property
@@ -310,7 +348,7 @@ class SPDXFile:
         self._purpose = purpose if purpose in self.supported_puposes else "other"
 
     def to_dict(self):
-        return {
+        result = {
             "type": "software_File",
             "spdxId": self.spdx_id,
             "software_copyrightText": "",
@@ -321,6 +359,9 @@ class SPDXFile:
             "verifiedUsing": [item.to_dict() for item in self.verified_using],
             "creationInfo": self.creation_info.spdx_id,
         }
+        if self.external_identifiers:
+            result["externalIdentifier"] = [ei.to_dict() for ei in self.external_identifiers]
+        return result
 
 
 class PositiveIntegerRange:
@@ -633,6 +674,23 @@ class SPDXManager:
                 relation_dict.pop(key, None)
         return relation_dict
 
+    def clean_snippet_annotation_dict(self, relation_dict):
+        """Remove fields from a snippet mapping dict that are already represented in
+        SPDX properties: offset/section are encoded in software_byteRange; coverage
+        is encoded in Relationship.completeness."""
+        redundant_keys = ["offset", "section", "coverage"]
+        for key in redundant_keys:
+            relation_dict.pop(key, None)
+        return relation_dict
+
+    @staticmethod
+    def clean_entity_annotation_dict(entity_dict):
+        """Remove id and title fields that are now represented as ExternalIdentifier
+        on the SPDX element, avoiding duplication with opaque annotation JSON."""
+        for key in ["id", "title"]:
+            entity_dict.pop(key, None)
+        return entity_dict
+
     def getSnippetIndex(self) -> int:
         """Get next id of a relationship"""
         relationships = [item for item in self.sbom if isinstance(item, SPDXSnippet)]
@@ -696,6 +754,11 @@ class SPDXManager:
         relation_id = mapping_dict["relation_id"]
         mapping_dict = self.clean_api_relation_dict(mapping_dict)
 
+        # Read byte range values before stripping redundant fields
+        byte_range_begin = mapping_dict["offset"] + 1
+        byte_range_end = mapping_dict["offset"] + len(mapping_dict["section"]) + 1
+        snippet_annotation_dict = self.clean_snippet_annotation_dict(dict(mapping_dict))
+
         snippet_id = f"spdx:snippet:api:{api_id}:{self.getSnippetIndex()}"
 
         creation_info, person = self.getCreationInfoAndPerson(
@@ -707,9 +770,7 @@ class SPDXManager:
             from_file=spdx_api_ref_doc_file,
             name=mapping.api.raw_specification_url,
             comment=f"Snippet of api {api} reference document",
-            byte_range=PositiveIntegerRange(
-                mapping_dict["offset"] + 1, mapping_dict["offset"] + len(mapping_dict["section"]) + 1
-            ),
+            byte_range=PositiveIntegerRange(byte_range_begin, byte_range_end),
             creation_info=creation_info,
         )
 
@@ -718,7 +779,7 @@ class SPDXManager:
             f"{api_id}:{mapping_to_id_prefix}:{mapping_to_id}:relation-id:{relation_id}",
             name=f"Annotation for BASIL API {api} snippet",
             subject=snippet,
-            object=mapping_dict,
+            object=snippet_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -757,14 +818,21 @@ class SPDXManager:
             purpose="module",
             copyright_text="",
             verified_using=[file_api_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{api.__tablename__}:{api.id}",
+                    comment=f"BASIL Software Component '{api.api}' with ID {api.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        api_annotation_dict = self.clean_entity_annotation_dict(dict(api_dict))
         file_api_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:api:{api_dict['id']}",
             name=f"Annotation for BASIL API {api.api} with ID {api.id}",
             subject=file_api,
-            object=api_dict,
+            object=api_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -854,14 +922,21 @@ class SPDXManager:
             purpose="requirement",
             copyright_text="",
             verified_using=[sr_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{software_requirement.__tablename__}:{software_requirement.id}",
+                    comment=f"BASIL Software Requirement '{software_requirement.title}' with ID {software_requirement.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        sr_annotation_dict = self.clean_entity_annotation_dict(dict(sr_dict))
         sr_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:software-requirement:{software_requirement.id}",
             name=f"Annotation for BASIL Software Requirement {software_requirement.id}",
             subject=sr_file,
-            object=sr_dict,
+            object=sr_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -891,14 +966,21 @@ class SPDXManager:
             purpose="specification",
             copyright_text="",
             verified_using=[ts_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{test_specification.__tablename__}:{test_specification.id}",
+                    comment=f"BASIL Test Specification '{test_specification.title}' with ID {test_specification.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        ts_annotation_dict = self.clean_entity_annotation_dict(dict(ts_dict))
         ts_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:test-specification:{test_specification.id}",
             name=f"Annotation for BASIL Test Specification {test_specification.id}",
             subject=ts_file,
-            object=ts_dict,
+            object=ts_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -925,14 +1007,21 @@ class SPDXManager:
             purpose="test",
             copyright_text="",
             verified_using=[tc_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{test_case.__tablename__}:{test_case.id}",
+                    comment=f"BASIL Test Case '{test_case.title}' with ID {test_case.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        tc_annotation_dict = self.clean_entity_annotation_dict(dict(tc_dict))
         tc_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:test-case:{test_case.id}",
             name=f"Annotation for BASIL Test Case {test_case.id}",
             subject=tc_file,
-            object=tc_dict,
+            object=tc_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -959,14 +1048,21 @@ class SPDXManager:
             purpose="documentation",
             copyright_text="",
             verified_using=[doc_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{document.__tablename__}:{document.id}",
+                    comment=f"BASIL Document '{document.title}' with ID {document.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        doc_annotation_dict = self.clean_entity_annotation_dict(dict(doc_dict))
         doc_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:document:{document.id}",
             name=f"Annotation for BASIL Document {document.id}",
             subject=doc_file,
-            object=doc_dict,
+            object=doc_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -996,14 +1092,21 @@ class SPDXManager:
             purpose="evidence",
             copyright_text="",
             verified_using=[js_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{justification.__tablename__}:{justification.id}",
+                    comment=f"BASIL Justification with ID {justification.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        js_annotation_dict = self.clean_entity_annotation_dict(dict(js_dict))
         js_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:justification:{justification.id}",
             name=f"Annotation for BASIL Justification {justification.id}",
             subject=js_file,
-            object=js_dict,
+            object=js_annotation_dict,
             creation_info=creation_info,
         )
 
@@ -1057,14 +1160,21 @@ class SPDXManager:
             purpose="evidence",
             copyright_text="",
             verified_using=[tr_hash],
+            external_identifiers=[
+                SPDXExternalIdentifier(
+                    identifier=f"basil:{test_run.__tablename__}:{test_run.id}",
+                    comment=f"BASIL Test Run '{test_run.title}' with ID {test_run.id}",
+                )
+            ],
             creation_info=creation_info,
         )
 
+        tr_annotation_dict = self.clean_entity_annotation_dict(dict(tr_dict))
         tr_annotation = SPDXAnnotation(
             spdx_id=f"spdx:annotation:basil:test-run:{test_run.id}",
             name=f"Annotation for BASIL Test Run {test_run.id}",
             subject=tr_file,
-            object=tr_dict,
+            object=tr_annotation_dict,
             creation_info=creation_info,
         )
 

--- a/api/spdx_manager.py
+++ b/api/spdx_manager.py
@@ -925,7 +925,10 @@ class SPDXManager:
             external_identifiers=[
                 SPDXExternalIdentifier(
                     identifier=f"basil:{software_requirement.__tablename__}:{software_requirement.id}",
-                    comment=f"BASIL Software Requirement '{software_requirement.title}' with ID {software_requirement.id}",
+                    comment=(
+                        f"BASIL Software Requirement '{software_requirement.title}'"
+                        f" with ID {software_requirement.id}"
+                    ),
                 )
             ],
             creation_info=creation_info,

--- a/api/test/test_spdx_api_validation.py
+++ b/api/test/test_spdx_api_validation.py
@@ -681,9 +681,9 @@ def test_spdx_sw_requirement_children_exported(client, user_authentication, comp
 
     # Bug 2 regression: sw_req_1 -> test_case_3 (via api_sw_requirement mapping sr_tc_mapping)
     assert has_relationship(
-        spdx_id_for_sr(sw_req_1), spdx_id_for_tc(test_case_3), "hasTest"
+        spdx_id_for_sr(sw_req_1), spdx_id_for_tc(test_case_3), "hasTestCase"
     ), (
-        f"Missing hasTest relationship: SW Requirement {sw_req_1.id} -> "
+        f"Missing hasTestCase relationship: SW Requirement {sw_req_1.id} -> "
         f"Test Case {test_case_3.id}. "
         "SW requirements directly mapped to the API must export their child test cases."
     )

--- a/api/test/test_spdx_api_validation.py
+++ b/api/test/test_spdx_api_validation.py
@@ -700,6 +700,256 @@ def test_spdx_sw_requirement_children_exported(client, user_authentication, comp
     print("✓ SW Requirement -> Test Specification/Case relationship export regression test passed")
 
 
+def _export_and_parse(client, user_authentication, api):
+    """Shared helper: trigger an SPDX export and return the parsed @graph list."""
+    response = client.get(
+        _SPDX_API_URL,
+        query_string={
+            "api-id": api.id,
+            "user-id": user_authentication.json["id"],
+            "token": user_authentication.json["token"],
+            "filename": "latest.jsonld",
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    return json.loads(response.data)["@graph"]
+
+
+def _external_identifiers_for(graph, spdx_id):
+    """Return the externalIdentifier list for the element with the given spdxId."""
+    for element in graph:
+        if element.get("spdxId") == spdx_id:
+            return element.get("externalIdentifier", [])
+    return []
+
+
+def _assert_external_identifier(graph, spdx_id, expected_identifier, expected_comment_fragment):
+    """Assert that the SPDX element carries the expected ExternalIdentifier."""
+    ext_ids = _external_identifiers_for(graph, spdx_id)
+    assert len(ext_ids) == 1, (
+        f"Element {spdx_id} should have exactly 1 externalIdentifier, got {ext_ids}"
+    )
+    ei = ext_ids[0]
+    assert ei["type"] == "ExternalIdentifier"
+    assert ei["externalIdentifierType"] == "other"
+    assert ei["identifier"] == expected_identifier, (
+        f"Expected identifier '{expected_identifier}', got '{ei['identifier']}'"
+    )
+    assert expected_comment_fragment in ei.get("comment", ""), (
+        f"Expected comment containing '{expected_comment_fragment}', got '{ei.get('comment')}'"
+    )
+
+
+def test_spdx_external_identifier_api(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on the software_File element for each API uses
+    basil:<tablename>:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    spdx_id = f"spdx:file:basil:api:{api.id}"
+    _assert_external_identifier(
+        graph,
+        spdx_id,
+        expected_identifier=f"basil:{api.__tablename__}:{api.id}",
+        expected_comment_fragment=str(api.id),
+    )
+    print(f"✓ ExternalIdentifier for API {api.id} validated")
+
+
+def test_spdx_external_identifier_sw_requirements(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each SW Requirement software_File uses
+    basil:sw_requirements:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for sr in test_data["sw_requirements"]:
+        spdx_id = f"spdx:file:basil:software-requirement:{sr.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{sr.__tablename__}:{sr.id}",
+            expected_comment_fragment=str(sr.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['sw_requirements'])} SW Requirements validated")
+
+
+def test_spdx_external_identifier_test_specifications(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each Test Specification software_File uses
+    basil:test_specifications:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for ts in test_data["test_specifications"]:
+        spdx_id = f"spdx:file:basil:test-specification:{ts.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{ts.__tablename__}:{ts.id}",
+            expected_comment_fragment=str(ts.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['test_specifications'])} Test Specifications validated")
+
+
+def test_spdx_external_identifier_test_cases(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each Test Case software_File uses
+    basil:test_cases:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for tc in test_data["test_cases"]:
+        spdx_id = f"spdx:file:basil:test-case:{tc.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{tc.__tablename__}:{tc.id}",
+            expected_comment_fragment=str(tc.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['test_cases'])} Test Cases validated")
+
+
+def test_spdx_external_identifier_justifications(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each Justification software_File uses
+    basil:justifications:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for js in test_data["justifications"]:
+        spdx_id = f"spdx:file:basil:justification:{js.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{js.__tablename__}:{js.id}",
+            expected_comment_fragment=str(js.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['justifications'])} Justifications validated")
+
+
+def test_spdx_external_identifier_documents(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each Document software_File uses
+    basil:documents:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for doc in test_data["documents"]:
+        spdx_id = f"spdx:file:basil:document:{doc.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{doc.__tablename__}:{doc.id}",
+            expected_comment_fragment=str(doc.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['documents'])} Documents validated")
+
+
+def test_spdx_external_identifier_test_runs(client, user_authentication, comprehensive_spdx_test_data):
+    """ExternalIdentifier on each Test Run software_File uses
+    basil:test_runs:<id> as identifier."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    for tr in test_data["test_runs"]:
+        spdx_id = f"spdx:file:basil:test-run:{tr.id}"
+        _assert_external_identifier(
+            graph,
+            spdx_id,
+            expected_identifier=f"basil:{tr.__tablename__}:{tr.id}",
+            expected_comment_fragment=str(tr.id),
+        )
+    print(f"✓ ExternalIdentifier for {len(test_data['test_runs'])} Test Runs validated")
+
+
+def test_spdx_annotation_version_injected(client, user_authentication, comprehensive_spdx_test_data):
+    """Every Annotation.statement in the SPDX output must carry
+    'basil:annotationVersion': '2.0'."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    annotations = [e for e in graph if e.get("type") == "Annotation"]
+    assert len(annotations) > 0, "Expected at least one Annotation in the SPDX output"
+
+    for annotation in annotations:
+        statement_raw = annotation.get("statement", "{}")
+        try:
+            statement = json.loads(statement_raw)
+        except json.JSONDecodeError:
+            pytest.fail(f"Annotation {annotation.get('spdxId')} has non-JSON statement: {statement_raw}")
+
+        assert statement.get("basil:annotationVersion") == "2.0", (
+            f"Annotation {annotation.get('spdxId')} is missing 'basil:annotationVersion': '2.0'. "
+            f"Statement keys: {list(statement.keys())}"
+        )
+    print(f"✓ basil:annotationVersion validated on {len(annotations)} annotations")
+
+
+def test_spdx_entity_annotations_have_no_id_or_title(client, user_authentication, comprehensive_spdx_test_data):
+    """Entity Annotation.statement must not contain 'id' or 'title' fields —
+    those are now represented via ExternalIdentifier on the element."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    entity_annotation_id_prefixes = (
+        "spdx:annotation:basil:api:",
+        "spdx:annotation:basil:software-requirement:",
+        "spdx:annotation:basil:test-specification:",
+        "spdx:annotation:basil:test-case:",
+        "spdx:annotation:basil:document:",
+        "spdx:annotation:basil:justification:",
+        "spdx:annotation:basil:test-run:",
+    )
+
+    entity_annotations = [
+        e for e in graph
+        if e.get("type") == "Annotation"
+        and any(e.get("spdxId", "").startswith(p) for p in entity_annotation_id_prefixes)
+    ]
+    assert len(entity_annotations) > 0, "Expected at least one entity Annotation in the SPDX output"
+
+    for annotation in entity_annotations:
+        statement = json.loads(annotation.get("statement", "{}"))
+        assert "id" not in statement, (
+            f"Annotation {annotation.get('spdxId')} still contains 'id' in statement. "
+            "It should have been moved to ExternalIdentifier."
+        )
+        assert "title" not in statement, (
+            f"Annotation {annotation.get('spdxId')} still contains 'title' in statement. "
+            "It should have been moved to ExternalIdentifier."
+        )
+    print(f"✓ No 'id'/'title' in {len(entity_annotations)} entity annotation statements")
+
+
+def test_spdx_snippet_annotations_stripped(client, user_authentication, comprehensive_spdx_test_data):
+    """Snippet Annotation.statement must not contain 'offset', 'section', or 'coverage' —
+    offset/section are encoded in software_byteRange; coverage in Relationship.completeness."""
+    test_data = comprehensive_spdx_test_data
+    api = test_data["api"]
+    graph = _export_and_parse(client, user_authentication, api)
+
+    snippet_annotations = [
+        e for e in graph
+        if e.get("type") == "Annotation"
+        and e.get("spdxId", "").startswith("spdx:annotation:snippet:")
+    ]
+    assert len(snippet_annotations) > 0, "Expected at least one snippet Annotation in the SPDX output"
+
+    for annotation in snippet_annotations:
+        statement = json.loads(annotation.get("statement", "{}"))
+        for redundant_key in ("offset", "section", "coverage"):
+            assert redundant_key not in statement, (
+                f"Snippet annotation {annotation.get('spdxId')} still contains '{redundant_key}'. "
+                "This field is already represented in a dedicated SPDX property."
+            )
+    print(f"✓ No redundant fields in {len(snippet_annotations)} snippet annotation statements")
+
+
 if __name__ == "__main__":
     # For manual testing/debugging
     pytest.main([__file__ + "::test_spdx_api_export_and_validation", "-v", "-s"])


### PR DESCRIPTION
Address the 3.0.1-addressable portion of the opaque-metadata gap identified in elisa-tech/Safety_Architecture_WG#18 (Gap 4).

All BASIL-specific metadata was previously serialised as raw JSON strings inside Annotation.statement fields, making entity identifiers and titles invisible to standard SPDX-aware tooling.

Changes in api/spdx_manager.py:

- Add BASIL_ANNOTATION_VERSION = "2.0" constant so consumers can distinguish the new annotation schema from the old one.

- Add SPDXExternalIdentifier class that serialises as a SPDX 3.0.1 ExternalIdentifier inline object (externalIdentifierType "other"). The identifier follows the convention basil:<db_tablename>:<db_id>, using the model's __tablename__ directly to stay in sync with the database schema without a separate mapping layer.

- Extend SPDXFile with an optional external_identifiers list; to_dict() emits "externalIdentifier": [...] when the list is non-empty.

- Populate ExternalIdentifier on every persisted BASIL entity: apis, sw_requirements, test_specifications, test_cases, documents, justifications, test_runs.

- Inject "basil:annotationVersion": "2.0" into every Annotation.statement automatically inside SPDXAnnotation.__init__, with no changes required at call sites.

- Add clean_entity_annotation_dict() helper that strips "id" and "title" from entity annotation payloads — both fields are now carried by the ExternalIdentifier on the element itself.

- Add clean_snippet_annotation_dict() helper that strips "offset", "section", and "coverage" from snippet annotation payloads — these are already represented in software_byteRange and Relationship.completeness respectively.

Changes in api/test/test_spdx_api_validation.py:

- Add helper functions _export_and_parse(), _external_identifiers_for(), and _assert_external_identifier() shared by the new tests.

- Add one dedicated test per entity type (api, sw_requirements, test_specifications, test_cases, justifications, documents, test_runs) that asserts the ExternalIdentifier carries the correct basil:<tablename>:<id> identifier and a comment containing the entity id.

- Add test_spdx_annotation_version_injected: every Annotation.statement
  must contain "basil:annotationVersion": "2.0".

- Add test_spdx_entity_annotations_have_no_id_or_title: entity annotation statements must not contain "id" or "title".

- Add test_spdx_snippet_annotations_stripped: snippet annotation statements must not contain "offset", "section", or "coverage".