### PR TITLE
Fix AI health-check 500 when AI is not configured

### DIFF
--- a/api/ai.py
+++ b/api/ai.py
@@ -158,8 +158,11 @@ class AIPrompter():
         else:
             self._max_tokens = self.DEFAULT_AI_MAX_TOKENS
 
-        self._host = str(self._host).rstrip("/")
-        self._api_version = str(self._api_version).rstrip("/")
+        # Avoid str(None) == "None", which looks like a configured host.
+        if self._host:
+            self._host = str(self._host).rstrip("/")
+        if self._api_version:
+            self._api_version = str(self._api_version).rstrip("/")
 
         if self._host and self._port:
             self._base_url = f"{self._host}:{self._port}/{self._api_version}"
@@ -167,20 +170,24 @@ class AIPrompter():
     def validate_settings(self) -> bool:
         """Validate mandatory fields"""
 
-        if self._host is None:
+        if not self._host:
             logger.warning("Error. `AI host` is not configured")
             return False
 
-        if self._port is None:
+        if not self._port:
             logger.warning("Error. `AI port` is not configured")
             return False
 
-        if self._api_version is None:
+        if not self._api_version:
             logger.warning("Error. `AI api version` is not configured")
             return False
 
-        if self._model is None:
+        if not self._model:
             logger.warning("Error. `AI model` is not configured")
+            return False
+
+        if not self._base_url:
+            logger.warning("Error. `AI base url` is not configured")
             return False
 
         logger.info("AIPromter settings are valid")
@@ -207,15 +214,20 @@ class AIPrompter():
         return text.strip()
 
     def ai_health_check(self):
+        if not self._base_url:
+            logger.warning("AIPrompter ai_health_check - base URL is not configured")
+            return False
+
         url = f"{self._base_url}/models"
-        req = urllib.request.Request(url, method="GET")
-
-        if self._base_url.startswith(self.GEMINI_BASE_URL):
-            req.add_header("x-goog-api-key", self._token)
-
-        req.add_header("Content-Type", "application/json")
 
         try:
+            req = urllib.request.Request(url, method="GET")
+
+            if self._base_url.startswith(self.GEMINI_BASE_URL):
+                req.add_header("x-goog-api-key", self._token)
+
+            req.add_header("Content-Type", "application/json")
+
             with urllib.request.urlopen(req, timeout=1) as resp:
                 status = resp.getcode()
                 if status == 200:
@@ -228,8 +240,8 @@ class AIPrompter():
             logger.error(f"❌ AIPrompter ai_health_check - HTTP error: {e.code}")
             return False
         except Exception:
-            # Network error, timeout, connection refused, etc.
-            logger.error("❌ AIPrompter ai_health_check - Connection failed",)
+            # Network error, timeout, connection refused, invalid URL, etc.
+            logger.error("❌ AIPrompter ai_health_check - Connection failed")
             return False
 
     def strip_outer_quotes(self, value: str) -> str:

--- a/api/test/test_ai.py
+++ b/api/test/test_ai.py
@@ -45,6 +45,24 @@ def test_wrong_settings():
 
     ai_prompter = AIPrompter(settings=None, settings_last_modified=None)
     assert not ai_prompter.validate_settings()
+    assert ai_prompter.ai_health_check() is False
+
+
+def test_placeholder_settings_are_invalid():
+    """Default settings.yaml uses empty host/model and port 0 as placeholders."""
+    delete_env_variables()
+
+    settings, settings_last_modified = load_settings(None, None)
+    settings[AIPrompter.SETTINGS_AI_SECTION] = {
+        AIPrompter.SETTINGS_AI_FIELD_HOST: "",
+        AIPrompter.SETTINGS_AI_FIELD_PORT: 0,
+        AIPrompter.SETTINGS_AI_FIELD_MODEL: "",
+        AIPrompter.SETTINGS_AI_FIELD_TOKEN: "",
+    }
+    ai_prompter = AIPrompter(settings=settings, settings_last_modified=settings_last_modified)
+    assert not ai_prompter.validate_settings()
+    assert ai_prompter._base_url is None
+    assert ai_prompter.ai_health_check() is False
 
 
 @pytest.mark.parametrize('mandatory_field', [


### PR DESCRIPTION
GET /ai/health-check crashed with ValueError: unknown url type 'None/models' because validate_settings() only rejected None. Default placeholders (empty host/model, port 0) passed validation, _base_url stayed unset, and urllib raised outside the try/except.

Treat empty values as unconfigured, avoid str(None) becoming the string "None", and return False from ai_health_check() when the base URL is missing so the UI can hide AI features instead of 500.

Solves #317 