### PR TITLE
Remap the example SPDX snippets onto the current README

### DIFF
--- a/examples/export/spdx.jsonld
+++ b/examples/export/spdx.jsonld
@@ -30,7 +30,7 @@
       "annotationType": "other",
       "spdxId": "spdx:annotation:snippet:api:2:software-requirement:4:relation-id:2",
       "subject": "spdx:snippet:api:2:1",
-      "statement": "{\"relation_id\": 2, \"section\": \"# BASIL\\n\\nA tool developed to manage software related work items, design their traceability towards specifications and source code and ensure completeness of analysis.\", \"offset\": 94, \"direct\": true, \"coverage\": 50, \"created_by\": \"one1\", \"covered\": 50, \"__tablename__\": \"sw_requirement_mapping_api\", \"gap\": 0, \"version\": \"1.1\", \"created_at\": \"2025-10-02 09:35\", \"updated_at\": \"2025-10-02 09:35\"}",
+      "statement": "{\"relation_id\": 2, \"section\": \"A tool developed to manage software related work items, design their traceability towards specifications and source code and ensure completeness of analysis.\", \"offset\": 940, \"direct\": true, \"coverage\": 50, \"created_by\": \"one1\", \"covered\": 50, \"__tablename__\": \"sw_requirement_mapping_api\", \"gap\": 0, \"version\": \"1.1\", \"created_at\": \"2025-10-02 09:35\", \"updated_at\": \"2025-10-02 09:35\"}",
       "creationInfo": "_:creation_info_spdx:snippet:api:2:1"
     },
     {
@@ -46,7 +46,7 @@
       "annotationType": "other",
       "spdxId": "spdx:annotation:snippet:api:2:software-requirement:5:relation-id:3",
       "subject": "spdx:snippet:api:2:2",
-      "statement": "{\"relation_id\": 3, \"section\": \"With BASIL you can decompose a Software Component Specification (or source code directly) in snippets and assign to each one a set of desired work items.\", \"offset\": 443, \"direct\": true, \"coverage\": 75, \"created_by\": \"one1\", \"covered\": 75, \"__tablename__\": \"sw_requirement_mapping_api\", \"gap\": 0, \"version\": \"1.1\", \"created_at\": \"2025-10-02 09:35\", \"updated_at\": \"2025-10-02 09:35\"}",
+      "statement": "{\"relation_id\": 3, \"section\": \"With BASIL you can decompose a Software Component Specification (or source code directly) in snippets and assign to each one a set of desired work items.\", \"offset\": 1280, \"direct\": true, \"coverage\": 75, \"created_by\": \"one1\", \"covered\": 75, \"__tablename__\": \"sw_requirement_mapping_api\", \"gap\": 0, \"version\": \"1.1\", \"created_at\": \"2025-10-02 09:35\", \"updated_at\": \"2025-10-02 09:35\"}",
       "creationInfo": "_:creation_info_spdx:snippet:api:2:2"
     },
     {
@@ -316,8 +316,8 @@
       "description": "",
       "software_byteRange": {
         "type": "PositiveIntegerRange",
-        "beginIntegerRange": 95,
-        "endIntegerRange": 261
+        "beginIntegerRange": 941,
+        "endIntegerRange": 1098
       },
       "software_snippetFromFile": "spdx:file:basil:api:reference-document:2",
       "creationInfo": "_:creation_info_spdx:snippet:api:2:1"
@@ -330,8 +330,8 @@
       "description": "",
       "software_byteRange": {
         "type": "PositiveIntegerRange",
-        "beginIntegerRange": 444,
-        "endIntegerRange": 597
+        "beginIntegerRange": 1281,
+        "endIntegerRange": 1434
       },
       "software_snippetFromFile": "spdx:file:basil:api:reference-document:2",
       "creationInfo": "_:creation_info_spdx:snippet:api:2:2"


### PR DESCRIPTION
## Problem

`examples/export/spdx.jsonld` points the reference document at:

https://raw.githubusercontent.com/elisa-tech/BASIL/refs/heads/main/README.md

The two snippets still use `software_byteRange` 95-261 and 444-597. Those offsets were measured against the README as it existed when the example mapping was created (2025-10-02). `main` has since grown a logo header and badge row, and the `# BASIL` heading is gone. Fetching `File.name` today highlights the badge preamble, not the mapped sections.

#300 corrected `beginIntegerRange` in this file but did not rematch the ranges to the current README.

## Follow-up

A later README edit will shift these ranges again. The exporter copies `api.raw_specification_url` into `File.name`, so a branch URL stays a moving target. Pinning the spec URL to a commit SHA when the mapping is created would help keep new exports self-consistent.
